### PR TITLE
refactor: centralize all initialization logic in a single module

### DIFF
--- a/hf-provider/src/gce_provider/__main__.py
+++ b/hf-provider/src/gce_provider/__main__.py
@@ -26,6 +26,7 @@ from gce_provider.commands.request_machines import request_machines
 from gce_provider.commands.request_return_machines import request_return_machines
 from gce_provider.config import Config, get_config
 from gce_provider.db.initialize import main as initialize_db
+from gce_provider.initialize import ensure_initialized
 from gce_provider.model.models import HFGceRequestMachines
 from gce_provider.pubsub import launch_pubsub_daemon, main as monitor_events
 from gce_provider.utils.constants import CommandNames
@@ -102,9 +103,8 @@ def cmd_get_available_templates(
     :return: the templates JSON
     """
 
-    # Initialize the database to avoid the need to explicitly declare $HF_DBDIR,
-    # thereby simplifying the installation process.
-    initialize_db(config)
+    # Ensure all initialization is done before proceeding
+    ensure_initialized(config)
 
     config.logger.info(f"cmd_get_available_templates; payload={payload}")
     config.logger.info(f"hf_provider_conf_dir: {config.hf_provider_conf_dir}")

--- a/hf-provider/src/gce_provider/initialize.py
+++ b/hf-provider/src/gce_provider/initialize.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import threading
+from typing import Any
+from gce_provider.db.initialize import main as initialize_db
+
+__all__ = ["ensure_initialized"]
+
+_initialized: bool = False
+_init_lock = threading.Lock()
+
+def _init_all(config: Any) -> None:
+    """Perform all synchronous initialization logic for the GCE provider."""
+    
+    # Initialize the database to avoid the need to explicitly declare $HF_DBDIR,
+    # thereby simplifying the installation process.
+    initialize_db(config)
+
+    # Add other initialization logic here as needed.
+    # ...
+
+
+def ensure_initialized(config: Any) -> None:
+    """Synchronous entrypoint that runs initialization exactly once per process."""
+    global _initialized
+
+    if _initialized:
+        return
+
+    with _init_lock:
+        if _initialized:
+            return
+
+        config.logger.info("Performing process-level initialization for GCE provider.")
+
+        try:
+            _init_all(config)
+            _initialized = True
+            config.logger.info("Initialization complete.")
+        except Exception:
+            config.logger.error("Initialization failed.")
+            raise


### PR DESCRIPTION
- Set _init_all() as the central process-level initialization function
- Retain the initialization process inside cmd_get_available_templates() as it appears to be the safest and maintainable way

Fixes #43 

- [ /] Tests pass
