### PR TITLE
fix: add usr/bin to path to resolve build failures

### DIFF
--- a/.github/workflows/build_rpm.yaml
+++ b/.github/workflows/build_rpm.yaml
@@ -29,6 +29,9 @@ jobs:
            dnf install -y ${{ matrix.python_pkg }} rpm-build nodejs
            alternatives --set python3 /usr/bin/python3.9 || true
 
+    - name: Add a directory to the PATH
+      run: echo "/usr/bin" >> $GITHUB_PATH
+
     - name: build clis
       run: |
            cd hf-provider


### PR DESCRIPTION
Unclear why this is necessary, but it appears to resolve the build failures


