### PR TITLE
Fix/50 hf provider failing unit tests

### DIFF
--- a/hf-provider/pyproject.toml
+++ b/hf-provider/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # ------------------------------
 [project]
 name = "google-symphony-hf"
-version = "0.3.5"
+version = "0.3.6"
 description = "Default template"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/hf-provider/tests/unit/gce_provider/db/test_gce_helpers.py
+++ b/hf-provider/tests/unit/gce_provider/db/test_gce_helpers.py
@@ -40,14 +40,14 @@ def test_list_managed_instances(mock_client, mock_managed_instance, mock_config)
         for i in range(2)
     ]
 
-    mock_client.list_managed_instances.return_value = mock_instances
+    mock_client.return_value.list_managed_instances.return_value = mock_instances
 
     result = fetch_managed_instance_list(
         "symphony-dev-1", "us-central1-c", "corykim-test-01"
     )
     assert mock_instances[0].instance in result
     assert mock_instances[1].instance in result
-    mock_client.list_managed_instances.assert_called_once()
+    mock_client.return_value.list_managed_instances.assert_called_once()
 
 
 @pytest.fixture
@@ -74,7 +74,7 @@ def mock_instance():
 def test_fetch_instance(mock_client, mock_instance):
     # Setup mock return value
     instance_name = "my-instance-1"
-    mock_client.get.return_value = mock_instance(
+    mock_client.return_value.get.return_value = mock_instance(
         instance_name, "10.0.0.100", "35.100.200.1"
     )
 
@@ -87,14 +87,14 @@ def test_fetch_instance(mock_client, mock_instance):
     assert instance.name == instance_name
     assert instance.network_interfaces[0].network_i_p == "10.0.0.100"
     assert instance.network_interfaces[0].access_configs[0].nat_ip == "35.100.200.1"
-    mock_client.get.assert_called_once()
+    mock_client.return_value.get.assert_called_once()
 
 
 @patch("gce_provider.db.gce_helpers.client_factory.instances_client")
 def test_fetch_instance_by_url(mock_client, mock_instance):
     # Setup mock return value
     instance_name = "my-instance-1"
-    mock_client.get.return_value = mock_instance(
+    mock_client.return_value.get.return_value = mock_instance(
         instance_name, "10.0.0.100", "35.100.200.1"
     )
 
@@ -105,7 +105,7 @@ def test_fetch_instance_by_url(mock_client, mock_instance):
     assert instance.name == instance_name
     assert instance.network_interfaces[0].network_i_p == "10.0.0.100"
     assert instance.network_interfaces[0].access_configs[0].nat_ip == "35.100.200.1"
-    mock_client.get.assert_called_once()
+    mock_client.return_value.get.assert_called_once()
 
 
 def generate_instance_url(
@@ -124,7 +124,7 @@ def test_fetch_instances(mock_client, mock_instance):
         for i, name in enumerate(instance_names)
     ]
 
-    mock_client.get.side_effect = mock_instances
+    mock_client.return_value.get.side_effect = mock_instances
 
     instance_args = [
         ResourceIdentifier(project=TEST_PROJECT, zone=TEST_ZONE, name=name)
@@ -136,7 +136,7 @@ def test_fetch_instances(mock_client, mock_instance):
 
     # Validate
     assert len(instances) == len(instance_names)
-    assert mock_client.get.call_count == len(instance_names)
+    assert mock_client.return_value.get.call_count == len(instance_names)
 
     for instance in instances:
         assert instance is not None
@@ -153,7 +153,7 @@ def test_fetch_many_instances(mock_client, mock_instance):
         for i, name in enumerate(instance_names)
     ]
 
-    mock_client.get.side_effect = mock_instances
+    mock_client.return_value.get.side_effect = mock_instances
 
     instance_args = [
         ResourceIdentifier(project=TEST_PROJECT, zone=TEST_ZONE, name=name)
@@ -165,7 +165,7 @@ def test_fetch_many_instances(mock_client, mock_instance):
 
     # Validate
     assert len(instances) == len(instance_names)
-    assert mock_client.get.call_count == len(instance_names)
+    assert mock_client.return_value.get.call_count == len(instance_names)
 
     for instance in instances:
         assert instance is not None
@@ -181,7 +181,7 @@ def test_fetch_instances_by_url(mock_client, mock_instance):
         for i, name in enumerate(instance_names)
     ]
 
-    mock_client.get.side_effect = mock_instances
+    mock_client.return_value.get.side_effect = mock_instances
 
     # Call the function under test
     instances = fetch_instances_by_url(
@@ -190,7 +190,7 @@ def test_fetch_instances_by_url(mock_client, mock_instance):
 
     # Validate
     assert len(instances) == len(instance_names)
-    assert mock_client.get.call_count == len(instance_names)
+    assert mock_client.return_value.get.call_count == len(instance_names)
 
     for instance in instances:
         assert instance is not None

--- a/hf-provider/tests/unit/gke_provider/test_client.py
+++ b/hf-provider/tests/unit/gke_provider/test_client.py
@@ -12,6 +12,7 @@ def test_load_kubernetes_config_kubeconfig(mock_config):
         patch("gke_provider.config.Config.__new__", return_value=mock_config),
         patch("kubernetes.config.load_kube_config") as mock_load_kube_config,
     ):
+        client.load_kubernetes_config.cache_clear()
         client.load_kubernetes_config()
         mock_load_kube_config.assert_called_once()
 
@@ -19,11 +20,12 @@ def test_load_kubernetes_config_kubeconfig(mock_config):
 def test_load_kubernetes_config_incluster(mock_config):
     """Test loading Kubernetes config from incluster config."""
     with (
-        patch.object(
-            client, "load_kubernetes_config", side_effect=config.ConfigException
+        patch(
+            "kubernetes.config.load_kube_config", side_effect=config.ConfigException
         ),
         patch("kubernetes.config.load_incluster_config") as mock_load_incluster_config,
     ):
+        client.load_kubernetes_config.cache_clear()
         client.load_kubernetes_config()
         mock_load_incluster_config.assert_called_once()
 
@@ -40,6 +42,7 @@ def test_load_kubernetes_config_failure(mock_config):
         ),
         pytest.raises(Exception),
     ):
+        client.load_kubernetes_config.cache_clear()
         client.load_kubernetes_config()
 
 

--- a/hf-provider/tests/unit/gke_provider/test_get_return_machine_status.py
+++ b/hf-provider/tests/unit/gke_provider/test_get_return_machine_status.py
@@ -1,7 +1,6 @@
-from gke_provider.commands import get_return_machine_status
-from unittest.mock import patch, MagicMock
 import pytest
-
+from unittest.mock import patch, MagicMock
+import gke_provider.commands.get_return_requests as get_return_requests
 
 def test_get_return_machine_status_success(mock_config, mock_hfr):
     """Test getting return machine status successfully."""
@@ -17,16 +16,16 @@ def test_get_return_machine_status_success(mock_config, mock_hfr):
             }
         ],
     ):
-        result = get_return_machine_status.get_return_machine_status(
-            mock_hfr, mock_config
-        )
+        
+        result = get_return_requests.get_return_requests(mock_hfr, mock_config)
         assert result is not None
 
 
 def test_get_return_machine_status_no_return_requests(mock_config, mock_hfr):
     """Test getting return machine status with no return requests."""
     mock_hfr.returnRequests = None
-    result = get_return_machine_status.get_return_machine_status(mock_hfr, mock_config)
+
+    result = get_return_requests.get_return_requests(mock_hfr, mock_config)
     assert "returnRequests must be present" in result["message"]
 
 
@@ -38,4 +37,5 @@ def test_get_return_machine_status_resource_error(mock_config, mock_hfr):
         "gke_provider.k8s.resources.get_all_gcpsymphonyresources",
         side_effect=Exception("Test Exception"),
     ), pytest.raises(Exception):
-        get_return_machine_status.get_return_machine_status(mock_hfr, mock_config)
+
+        get_return_requests.get_return_requests(mock_hfr, mock_config)

--- a/hf-provider/tests/unit/gke_provider/test_request_machines.py
+++ b/hf-provider/tests/unit/gke_provider/test_request_machines.py
@@ -8,6 +8,8 @@ def test_request_machines_success(mock_config, mock_hfr):
     mock_hfr.requestMachines = MagicMock()
     mock_hfr.requestMachines.template = MagicMock()
     mock_hfr.requestMachines.template.machineCount = 2
+    mock_config.crd_label_name_text = "test-label"
+    mock_config.crd_label_value_text = "test-value"
     mock_hfr.pod_spec = {"test": "spec"}
     with patch(
         "gke_provider.k8s.resources.create_gcpsymphonyresource",


### PR DESCRIPTION
Fixes #50

This pull request addresses and fixes the failing unit test cases in the hf-provider module.
Bump version 0.3.5 to 0.3.6.

## Steps to Reproduce the Problem

1. Go to hf-provider directory
2. Run `export HF_PROVIDER_CONFDIR=<PATH>/gcpgkeinst && source <VENV PATH>/bin/activate && python -m pytest tests/unit/common -v` for common
3. Run `export HF_PROVIDER_CONFDIR=<PATH>/gcpgkeinst && source <VENV PATH>/bin/activate && python -m pytest tests/unit/gke_provider` for HF GKE
4. Run `export HF_PROVIDER_CONFDIR=<PATH>/gcpgceinst && source <VENV PATH>/bin/activate && python -m pytest tests/unit/gce_provider` for HF GCE