### PR TITLE
Fix/51 k8s operator failing unit tests

### DIFF
--- a/k8s-operator/pyproject.toml
+++ b/k8s-operator/pyproject.toml
@@ -20,7 +20,7 @@ description = "An operator for the IBM Spectrum Symphony hostfactory plugin for 
 name = "gcp-symphony-operator"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.2.6"
+version = "0.2.7"
 
 [project.optional-dependencies]
 dev = [

--- a/k8s-operator/tests/test_integration/test_operator_integration.py
+++ b/k8s-operator/tests/test_integration/test_operator_integration.py
@@ -20,7 +20,7 @@ class TestOperatorIntegration:
     @pytest.fixture
     def test_namespace(
         self: Self,
-    ) -> Generator[Any, None]:
+    ) -> Generator[Any, None, None]:
         """Create a test namespace for integration tests."""
         namespace_name = "test-symphony-operator"
         api = k8s.CoreV1Api()

--- a/k8s-operator/tests/test_unit/handlers/test_pod_delete.py
+++ b/k8s-operator/tests/test_unit/handlers/test_pod_delete.py
@@ -57,6 +57,7 @@ class TestPodDeleteHandler:
             status=None,
             old=None,
             new=None,
+            diff=None,
             logger=mock_logger,
         )
 
@@ -96,19 +97,20 @@ class TestPodDeleteHandler:
         }
 
         # Call the handler
-        with pytest.raises(ApiException) as exc_info:
-            await handler(
-                meta=mock_meta,
-                spec=None,
-                status=None,
-                old=None,
-                new=None,
-                logger=mock_logger,
-            )
+        await handler(
+            meta=mock_meta,
+            spec=None,
+            status=None,
+            old=None,
+            new=None,
+            diff=None,
+            logger=mock_logger,
+        )
 
-        # Verify the error message
-        assert "Owner resource test-owner of kind TestKind not found" in str(
-            exc_info.value
+        # Verify the warning message
+        mock_logger.warning.assert_called_with(
+            f"{mock_config.crd_kind} test-owner not found, kopf should handle, "
+            f"but double check and make sure pod test-pod has been deleted"
         )
 
         # Assertions
@@ -144,6 +146,7 @@ class TestPodDeleteHandler:
             status=None,
             old=None,
             new=None,
+            diff=None,
             logger=mock_logger,
         )
 
@@ -181,18 +184,66 @@ class TestPodDeleteHandler:
                 status=None,
                 old=None,
                 new=None,
+                diff=None,
                 logger=mock_logger,
             )
 
         # Assertions
         mock_logger.error.assert_called_with("Pod test-pod has no request ID label")
 
-    async def test_pod_delete_handler_no_request_id_raises_temporary_error(
+    @patch("gcp_symphony_operator.handlers.pod_delete.call_get_custom_object")
+    async def test_pod_delete_handler_api_exception(
         self: Self,
+        mock_get_custom_object: AsyncMock,
         mock_config: Config,
         mock_logger: MagicMock,
     ) -> None:
-        """Test handling of missing request ID label raises TemporaryError."""
+        """Test handling of API exception (non-404)."""
+        # Setup
+        mock_config.operator_name = "test-operator"
+        mock_config.crd_plural = "test-plural"
+        mock_config.crd_kind = "TestKind"
+
+        handler = pod_delete_handler_factory(mock_config, mock_logger)
+        mock_get_custom_object.side_effect = ApiException(
+            status=500, reason="Internal Server Error"
+        )
+
+        mock_meta = {
+            "name": "test-pod",
+            "namespace": "test-namespace",
+            "labels": {
+                "app": "test-owner",
+                "managed-by": "test-operator",
+                "symphony.requestId": "test-request-id",
+            },
+        }
+
+        # Call the handler
+        await handler(
+            meta=mock_meta,
+            spec=None,
+            status=None,
+            old=None,
+            new=None,
+            diff=None,
+            logger=mock_logger,
+        )
+
+        # Assertions
+        mock_logger.error.assert_called()
+        assert "Error updating TestKind test-owner" in str(
+            mock_logger.error.call_args[0][0]
+        )
+
+    @patch("gcp_symphony_operator.handlers.pod_delete.call_get_custom_object")
+    async def test_pod_delete_handler_owner_marked_for_deletion(
+        self: Self,
+        mock_get_custom_object: AsyncMock,
+        mock_config: Config,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test handling when owner is marked for deletion."""
         # Setup
         mock_config.operator_name = "test-operator"
         mock_config.crd_plural = "test-plural"
@@ -200,26 +251,133 @@ class TestPodDeleteHandler:
 
         handler = pod_delete_handler_factory(mock_config, mock_logger)
 
+        mock_get_custom_object.return_value = {
+            "metadata": {"markedForDeletion": "true"},
+        }
+
         mock_meta = {
             "name": "test-pod",
             "namespace": "test-namespace",
             "labels": {
-                "managed-by": "test-operator",
                 "app": "test-owner",
-                # No symphony.requestId label
+                "managed-by": "test-operator",
+                "symphony.requestId": "test-request-id",
             },
         }
 
-        # Call the handler and expect TemporaryError
-        with pytest.raises(kopf.TemporaryError):
+        # Call the handler
+        await handler(
+            meta=mock_meta,
+            spec=None,
+            status=None,
+            old=None,
+            new=None,
+            diff=None,
+            logger=mock_logger,
+        )
+
+        # Assertions
+        mock_logger.debug.assert_called_with(
+            "TestKind: test-owner is marked for deletion, skipping update."
+        )
+
+    @patch("gcp_symphony_operator.handlers.pod_delete.call_get_custom_object")
+    async def test_pod_delete_handler_owner_none(
+        self: Self,
+        mock_get_custom_object: AsyncMock,
+        mock_config: Config,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test handling when owner resource is None."""
+        # Setup
+        mock_config.operator_name = "test-operator"
+        mock_config.crd_plural = "test-plural"
+        mock_config.crd_kind = "TestKind"
+
+        handler = pod_delete_handler_factory(mock_config, mock_logger)
+        mock_get_custom_object.return_value = None
+
+        mock_meta = {
+            "name": "test-pod",
+            "namespace": "test-namespace",
+            "labels": {
+                "app": "test-owner",
+                "managed-by": "test-operator",
+                "symphony.requestId": "test-request-id",
+            },
+        }
+
+        # Call the handler
+        with pytest.raises(ApiException) as exc_info:
             await handler(
                 meta=mock_meta,
                 spec=None,
                 status=None,
                 old=None,
                 new=None,
+                diff=None,
                 logger=mock_logger,
             )
 
+        assert "Owner resource test-owner of kind TestKind not found" in str(
+            exc_info.value
+        )
+
+    @patch("gcp_symphony_operator.handlers.pod_delete.enqueue_status_update")
+    @patch("gcp_symphony_operator.handlers.pod_delete.call_get_custom_object")
+    async def test_pod_delete_handler_pod_already_returned(
+        self: Self,
+        mock_get_custom_object: AsyncMock,
+        mock_enqueue: AsyncMock,
+        mock_config: Config,
+        mock_logger: MagicMock,
+    ) -> None:
+        """Test handling when pod is already in returnedMachines."""
+        # Setup
+        mock_config.operator_name = "test-operator"
+        mock_config.crd_plural = "test-plural"
+        mock_config.crd_kind = "TestKind"
+
+        handler = pod_delete_handler_factory(mock_config, mock_logger)
+
+        mock_get_custom_object.return_value = {
+            "metadata": {"resourceVersion": "123"},
+            "status": {
+                "returnedMachines": [
+                    {
+                        "name": "test-pod",
+                        "returnRequestId": "test-return-id",
+                        "returnTime": "2023-01-01T00:00:00Z",
+                    }
+                ]
+            },
+        }
+
+        mock_meta = {
+            "name": "test-pod",
+            "namespace": "test-namespace",
+            "labels": {
+                "app": "test-owner",
+                "managed-by": "test-operator",
+                "symphony.requestId": "test-request-id",
+                "symphony.returnRequestId": "test-return-id",
+            },
+        }
+
+        # Call the handler
+        await handler(
+            meta=mock_meta,
+            spec=None,
+            status=None,
+            old=None,
+            new=None,
+            diff=None,
+            logger=mock_logger,
+        )
+
         # Assertions
-        mock_logger.error.assert_called_with("Pod test-pod has no request ID label")
+        mock_enqueue.assert_called_once()
+        # Verify call args to ensure correct list passed (no duplicate)
+        call_args = mock_enqueue.call_args[0][0]
+        assert len(call_args.returned_machines) == 1
+        assert call_args.returned_machines[0].name == "test-pod"

--- a/k8s-operator/tests/test_unit/types/test_gcp_symphony_resource.py
+++ b/k8s-operator/tests/test_unit/types/test_gcp_symphony_resource.py
@@ -99,12 +99,12 @@ def test_returned_machine_valid() -> None:
     data = {
         "name": "test-machine",
         "returnRequestId": "test-request-id",
-        "returnRequestTime": datetime.datetime.now(datetime.timezone.utc),
+        "returnTime": datetime.datetime.now(datetime.timezone.utc),
     }
     returned_machine = ReturnedMachine(**data)
     assert returned_machine.name == data["name"]
     assert returned_machine.returnRequestId == data["returnRequestId"]
-    assert returned_machine.returnRequestTime == data["returnRequestTime"]
+    assert returned_machine.returnTime == data["returnTime"]
 
 
 def test_returned_machine_invalid_timezone() -> None:
@@ -112,7 +112,7 @@ def test_returned_machine_invalid_timezone() -> None:
     data = {
         "name": "test-machine",
         "returnRequestId": "test-request-id",
-        "returnRequestTime": datetime.datetime.now(),  # No timezone
+        "returnTime": datetime.datetime.now(), # No timezone info
     }
     with pytest.raises(ValidationError):
         ReturnedMachine(**data)
@@ -123,7 +123,7 @@ def test_gcpsymphonyresourcestatus_valid() -> None:
     returned_machine = ReturnedMachine(
         name="test-machine",
         returnRequestId="test-request-id",
-        returnRequestTime=datetime.datetime.now(datetime.timezone.utc),
+        returnTime=datetime.datetime.now(datetime.timezone.utc),
     )
     data = {
         "phase": "Running",


### PR DESCRIPTION
Fixes #51

This pull request addresses and fixes the failing unit test cases in the k8s-operator module.
Bump version 0.2.6 to 0.2.7

## Steps to Reproduce the Problem

1. Go to k8s-operator directory
2. Run `source <VENV PATH>/.venv/bin/activate && python -m pytest`