### PR TITLE
fix: typo in k8s operator README

### DIFF
--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -76,7 +76,7 @@ that HostFactory returns, improving performance of the CLI.
 - pip
 - Kubernetes cluster for testing (minikube, kind, etc.)
 
-These instructions will descring the use of `uv`, "an extremely fast Python package manager."  It is recommended to use `uv` as the document describes, but it is not a hard requirement.
+These instructions describe the use of `uv`,an extremely fast Python package manager. While using `uv` is highly recommended, it is not strictly required.
 
 ### <a id="installation"></a>Installation
 


### PR DESCRIPTION
To fix the typo in k8s operator README
