### PR TITLE
Feat/k8s resource itest

### DIFF
--- a/k8s-operator/tests/ci/kind-tests/manifests/resource.yaml
+++ b/k8s-operator/tests/ci/kind-tests/manifests/resource.yaml
@@ -1,0 +1,103 @@
+apiVersion: accenture.com/v1
+kind: GCPSymphonyResource
+metadata:
+  name: test-resource-5
+  namespace: gcp-symphony
+  uid: test-uid
+  labels:
+    symphony.requestId: test-request-id-5
+spec:
+  machineCount: 1
+  namePrefix: test
+  podSpec:
+    containers:
+    - name: base-pod
+      image: nginx:alpine
+
+
+# apiVersion: accenture.com/v1
+# kind: MachineReturnRequest
+# metadata:
+#   annotations:
+#     kopf.zalando.org/last-handled-configuration: |
+#       {"spec":{"machineIds":["test-resource-4-pod-0"],"requestId":"test-request-return-id-4"},"metadata":{"labels":{"symphony.waitingCleanup":"True","triggerUpdate":"true"}}}
+#     kubectl.kubernetes.io/last-applied-configuration: |
+#       {"apiVersion":"accenture.com/v1","kind":"MachineReturnRequest","metadata":{"annotations":{},"name":"test-return-request-4","namespace":"gcp-symphony"},"spec":{"machineIds":["test-resource-4-pod-0"],"requestId":"test-request-return-id-4"}}
+#   creationTimestamp: "2026-04-21T13:52:02Z"
+#   generation: 1
+#   labels:
+#     symphony.waitingCleanup: "True"
+#     triggerUpdate: "true"
+#   name: test-return-request-4
+#   namespace: gcp-symphony
+#   resourceVersion: "187683"
+#   uid: 1cbca77e-6673-4539-880f-f6121e14613d
+# spec:
+#   machineIds:
+#   - test-resource-4-pod-0
+#   requestId: test-request-return-id-4
+# status:
+#   conditions:
+#   - lastTransitionTime: "2026-04-21T13:52:02.247943+00:00"
+#     message: Successfully returned all 1 pods
+#     reason: AllPodsDeleted
+#     status: "True"
+#     type: AllPodsDeleted
+#   failedMachines: 0
+#   machineEvents:
+#     test-resource-4-pod-0:
+#       message: Pod deletion successful
+#       returnCompletionTime: "2026-04-21T13:52:02.230692+00:00"
+#       returnRequestTime: "2026-04-21T13:52:02.044416+00:00"
+#       status: Completed
+#   phase: Completed
+#   returnedMachines: 1
+#   totalMachines: 1
+
+# apiVersion: accenture.com/v1
+# kind: GCPSymphonyResource
+# metadata:
+#   annotations:
+#     kopf.zalando.org/last-handled-configuration: |
+#       {"spec":{"machineCount":1,"namePrefix":"test","podSpec":{"containers":[{"image":"nginx:alpine","name":"base-pod"}]}},"metadata":{"labels":{"symphony.requestId":"test-request-id-4","symphony.waitingCleanup":"True"}},"status":{"availableMachines":0}}
+#     kubectl.kubernetes.io/last-applied-configuration: |
+#       {"apiVersion":"accenture.com/v1","kind":"GCPSymphonyResource","metadata":{"annotations":{},"labels":{"symphony.requestId":"test-request-id-4"},"name":"test-resource-4","namespace":"gcp-symphony","uid":"test-uid"},"spec":{"machineCount":1,"namePrefix":"test","podSpec":{"containers":[{"image":"nginx:alpine","name":"base-pod"}]}}}
+#   creationTimestamp: "2026-04-21T13:51:17Z"
+#   generation: 1
+#   labels:
+#     symphony.requestId: test-request-id-4
+#     symphony.waitingCleanup: "True"
+#   name: test-resource-4
+#   namespace: gcp-symphony
+#   resourceVersion: "187688"
+#   uid: 5d6c5509-cfc6-471d-90a0-41e9b61e18af
+# spec:
+#   machineCount: 1
+#   namePrefix: test
+#   podSpec:
+#     containers:
+#     - image: nginx:alpine
+#       name: base-pod
+# status:
+#   availableMachines: 0
+#   conditions:
+#   - lastTransitionTime: "2026-04-21T13:51:19.233110+00:00"
+#     message: All containers in pod test-resource-4-pod-0 are ready
+#     reason: ContainersReady
+#     status: "True"
+#     type: ContainerHealth
+#   - lastTransitionTime: "2026-04-21T13:52:02.242982+00:00"
+#     message: Pod test-resource-4-pod-0 has been returned
+#     reason: Returned
+#     status: "True"
+#     type: PodReturned
+#   - lastTransitionTime: "2026-04-21T13:52:02.450747+00:00"
+#     message: GCPSymphonyResource test-resource-4 has no pods.
+#     reason: NoPods
+#     status: "True"
+#     type: Completed
+#   phase: WaitingCleanup
+#   returnedMachines:
+#   - name: test-resource-4-pod-0
+#     returnRequestId: unknown
+#     returnTime: "2026-04-21T13:52:02.242968+00:00"

--- a/k8s-operator/tests/ci/kind-tests/manifests/resource.yaml
+++ b/k8s-operator/tests/ci/kind-tests/manifests/resource.yaml
@@ -1,11 +1,11 @@
 apiVersion: accenture.com/v1
 kind: GCPSymphonyResource
 metadata:
-  name: test-resource-5
+  name: test-resource
   namespace: gcp-symphony
   uid: test-uid
   labels:
-    symphony.requestId: test-request-id-5
+    symphony.requestId: test-request-id
 spec:
   machineCount: 1
   namePrefix: test
@@ -14,46 +14,7 @@ spec:
     - name: base-pod
       image: nginx:alpine
 
-
-# apiVersion: accenture.com/v1
-# kind: MachineReturnRequest
-# metadata:
-#   annotations:
-#     kopf.zalando.org/last-handled-configuration: |
-#       {"spec":{"machineIds":["test-resource-4-pod-0"],"requestId":"test-request-return-id-4"},"metadata":{"labels":{"symphony.waitingCleanup":"True","triggerUpdate":"true"}}}
-#     kubectl.kubernetes.io/last-applied-configuration: |
-#       {"apiVersion":"accenture.com/v1","kind":"MachineReturnRequest","metadata":{"annotations":{},"name":"test-return-request-4","namespace":"gcp-symphony"},"spec":{"machineIds":["test-resource-4-pod-0"],"requestId":"test-request-return-id-4"}}
-#   creationTimestamp: "2026-04-21T13:52:02Z"
-#   generation: 1
-#   labels:
-#     symphony.waitingCleanup: "True"
-#     triggerUpdate: "true"
-#   name: test-return-request-4
-#   namespace: gcp-symphony
-#   resourceVersion: "187683"
-#   uid: 1cbca77e-6673-4539-880f-f6121e14613d
-# spec:
-#   machineIds:
-#   - test-resource-4-pod-0
-#   requestId: test-request-return-id-4
-# status:
-#   conditions:
-#   - lastTransitionTime: "2026-04-21T13:52:02.247943+00:00"
-#     message: Successfully returned all 1 pods
-#     reason: AllPodsDeleted
-#     status: "True"
-#     type: AllPodsDeleted
-#   failedMachines: 0
-#   machineEvents:
-#     test-resource-4-pod-0:
-#       message: Pod deletion successful
-#       returnCompletionTime: "2026-04-21T13:52:02.230692+00:00"
-#       returnRequestTime: "2026-04-21T13:52:02.044416+00:00"
-#       status: Completed
-#   phase: Completed
-#   returnedMachines: 1
-#   totalMachines: 1
-
+########################## GCPSR DETAILS FOR THE SAMPLE TEST CASE ##########################
 # apiVersion: accenture.com/v1
 # kind: GCPSymphonyResource
 # metadata:
@@ -101,3 +62,44 @@ spec:
 #   - name: test-resource-4-pod-0
 #     returnRequestId: unknown
 #     returnTime: "2026-04-21T13:52:02.242968+00:00"
+
+
+############################ MRR DETAILS FOR SAMPLE TEST CASE ###################################
+# apiVersion: accenture.com/v1
+# kind: MachineReturnRequest
+# metadata:
+#   annotations:
+#     kopf.zalando.org/last-handled-configuration: |
+#       {"spec":{"machineIds":["test-resource-4-pod-0"],"requestId":"test-request-return-id-4"},"metadata":{"labels":{"symphony.waitingCleanup":"True","triggerUpdate":"true"}}}
+#     kubectl.kubernetes.io/last-applied-configuration: |
+#       {"apiVersion":"accenture.com/v1","kind":"MachineReturnRequest","metadata":{"annotations":{},"name":"test-return-request-4","namespace":"gcp-symphony"},"spec":{"machineIds":["test-resource-4-pod-0"],"requestId":"test-request-return-id-4"}}
+#   creationTimestamp: "2026-04-21T13:52:02Z"
+#   generation: 1
+#   labels:
+#     symphony.waitingCleanup: "True"
+#     triggerUpdate: "true"
+#   name: test-return-request-4
+#   namespace: gcp-symphony
+#   resourceVersion: "187683"
+#   uid: 1cbca77e-6673-4539-880f-f6121e14613d
+# spec:
+#   machineIds:
+#   - test-resource-4-pod-0
+#   requestId: test-request-return-id-4
+# status:
+#   conditions:
+#   - lastTransitionTime: "2026-04-21T13:52:02.247943+00:00"
+#     message: Successfully returned all 1 pods
+#     reason: AllPodsDeleted
+#     status: "True"
+#     type: AllPodsDeleted
+#   failedMachines: 0
+#   machineEvents:
+#     test-resource-4-pod-0:
+#       message: Pod deletion successful
+#       returnCompletionTime: "2026-04-21T13:52:02.230692+00:00"
+#       returnRequestTime: "2026-04-21T13:52:02.044416+00:00"
+#       status: Completed
+#   phase: Completed
+#   returnedMachines: 1
+#   totalMachines: 1

--- a/k8s-operator/tests/ci/kind-tests/manifests/return-resource.yaml
+++ b/k8s-operator/tests/ci/kind-tests/manifests/return-resource.yaml
@@ -1,0 +1,9 @@
+apiVersion: accenture.com/v1
+kind: MachineReturnRequest
+metadata:
+  name: test-return-request-5
+  namespace: gcp-symphony
+spec:
+  requestId: test-request-return-id-5
+  machineIds:
+  - "test-resource-5-pod-0"

--- a/k8s-operator/tests/ci/kind-tests/manifests/return-resource.yaml
+++ b/k8s-operator/tests/ci/kind-tests/manifests/return-resource.yaml
@@ -1,9 +1,9 @@
 apiVersion: accenture.com/v1
 kind: MachineReturnRequest
 metadata:
-  name: test-return-request-5
+  name: test-return-request
   namespace: gcp-symphony
 spec:
-  requestId: test-request-return-id-5
+  requestId: test-request-return-id
   machineIds:
-  - "test-resource-5-pod-0"
+  - "test-resource-pod-0"

--- a/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
@@ -5,18 +5,15 @@
 set -Eeuo pipefail
 
 RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/resource.yaml"
-NAMESPACE="gcp-symphony"
 RESOURCE_NAME="test-resource"
 
 kubectl apply -f "${RESOURCE_MANIFEST}"
 
 kubectl wait --for=create pod \
-    -n "$NAMESPACE" \
     -l "app=$RESOURCE_NAME" \
-    --timeout=30s
+    --timeout=60s
 
 kubectl wait --for=condition=Ready pod \
-    -n "$NAMESPACE" \
     -l "app=$RESOURCE_NAME" \
     --timeout=60s
 

--- a/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Purpose:
+# Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
+
+set -Eeuo pipefail
+
+RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/resource.yaml"
+NAMESPACE="gcp-symphony"
+LABEL="app=test-resource-5"
+
+# kubectl apply -f "${RESOURCE_MANIFEST}"
+
+kubectl wait --for=create pod\
+    -n "$NAMESPACE" \
+    -l "$LABEL" \
+    --timeout=30s
+
+kubectl wait --for=condition=Ready pod\
+    -n "$NAMESPACE" \
+    -l "$LABEL" \
+    --timeout=60s
+
+for pod in $(kubectl get pods -n "${NAMESPACE}" -l "${LABEL}" -o jsonpath='{.items[*].metadata.name}'); do
+    STATUS=$(kubectl get pod "$pod" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
+
+    if [[ "$STATUS" != "Running" ]]; then
+        echo "Pod $pod is not running (status: $STATUS)"
+        exit 1
+    fi
+    
+    echo "Pod $pod is Running."
+done
+
+echo "All pods are running successfully!"

--- a/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
@@ -1,34 +1,23 @@
 #!/usr/bin/env bash
-# Purpose:
+# Purpose: Validate that applying a resource request results in creating pods and are ready to use
 # Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
 
 set -Eeuo pipefail
 
 RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/resource.yaml"
 NAMESPACE="gcp-symphony"
-LABEL="app=test-resource"
+RESOURCE_NAME="test-resource"
 
-# kubectl apply -f "${RESOURCE_MANIFEST}"
+kubectl apply -f "${RESOURCE_MANIFEST}"
 
-kubectl wait --for=create pod\
+kubectl wait --for=create pod \
     -n "$NAMESPACE" \
-    -l "$LABEL" \
+    -l "app=$RESOURCE_NAME" \
     --timeout=30s
 
-kubectl wait --for=condition=Ready pod\
+kubectl wait --for=condition=Ready pod \
     -n "$NAMESPACE" \
-    -l "$LABEL" \
+    -l "app=$RESOURCE_NAME" \
     --timeout=60s
 
-for pod in $(kubectl get pods -n "${NAMESPACE}" -l "${LABEL}" -o jsonpath='{.items[*].metadata.name}'); do
-    STATUS=$(kubectl get pod "$pod" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
-
-    if [[ "$STATUS" != "Running" ]]; then
-        echo "Pod $pod is not running (status: $STATUS)"
-        exit 1
-    fi
-    
-    echo "Pod $pod is Running."
-done
-
-echo "All pods are running successfully!"
+echo "[PASS] Resource request successfully created and initialized pods."

--- a/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_machines_integration.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 
 RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/resource.yaml"
 NAMESPACE="gcp-symphony"
-LABEL="app=test-resource-5"
+LABEL="app=test-resource"
 
 # kubectl apply -f "${RESOURCE_MANIFEST}"
 

--- a/k8s-operator/tests/ci/kind-tests/test_request_machines_running_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_machines_running_assert.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Purpose: Validate that all requested machines are running and the resource state is consistent.
+# Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
+
+set -Eeuo pipefail
+
+NAMESPACE="gcp-symphony"
+RESOURCE_NAME="test-resource"
+
+for pod in $(kubectl get pods -n "${NAMESPACE}" -l "app=${RESOURCE_NAME}" -o jsonpath='{.items[*].metadata.name}'); do
+    STATUS=$(kubectl get pod "$pod" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
+
+    if [[ "$STATUS" != "Running" ]]; then
+        echo "[FAIL] Pod $pod is not running (current status: $STATUS)"
+        exit 1
+    fi
+done
+
+SR_MACHINE_COUNT=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.spec.machineCount}')
+SR_AVAILABLE_MACHINES=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.availableMachines}')
+SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
+POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
+
+if [[ 
+    $SR_MACHINE_COUNT != $SR_AVAILABLE_MACHINES || \
+    $SR_AVAILABLE_MACHINES != $POD_COUNT || \
+    $SR_PHASE != "Running" 
+]] then
+    echo "[FAIL] Resources mismatch:"
+    echo " - Requested machines: $SR_MACHINE_COUNT"
+    echo " - Available machines: $SR_AVAILABLE_MACHINES"
+    echo " - Running pods:       $POD_COUNT"
+    echo " - Resource phase:     $SR_PHASE"
+    exit 1
+fi
+
+echo "[PASS] All machines are running and the resource state is consistent."

--- a/k8s-operator/tests/ci/kind-tests/test_request_machines_running_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_machines_running_assert.sh
@@ -4,11 +4,10 @@
 
 set -Eeuo pipefail
 
-NAMESPACE="gcp-symphony"
 RESOURCE_NAME="test-resource"
 
-for pod in $(kubectl get pods -n "${NAMESPACE}" -l "app=${RESOURCE_NAME}" -o jsonpath='{.items[*].metadata.name}'); do
-    STATUS=$(kubectl get pod "$pod" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
+for pod in $(kubectl get pods -l "app=${RESOURCE_NAME}" -o jsonpath='{.items[*].metadata.name}'); do
+    STATUS=$(kubectl get pod "$pod" -o jsonpath='{.status.phase}')
 
     if [[ "$STATUS" != "Running" ]]; then
         echo "[FAIL] Pod $pod is not running (current status: $STATUS)"
@@ -16,10 +15,12 @@ for pod in $(kubectl get pods -n "${NAMESPACE}" -l "app=${RESOURCE_NAME}" -o jso
     fi
 done
 
+sleep 2
+
 SR_MACHINE_COUNT=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.spec.machineCount}')
 SR_AVAILABLE_MACHINES=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.availableMachines}')
 SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
-POD_COUNT=$(kubectl get pods -n "${NAMESPACE}" -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
+POD_COUNT=$(kubectl get pods -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
 
 if [[ 
     $SR_MACHINE_COUNT != $SR_AVAILABLE_MACHINES || \

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Purpose:
+# Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
+
+set -Eeuo pipefail
+
+RETURN_RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/return-resource.yaml"
+NAMESPACE="gcp-symphony"
+LABEL="app=test-resource-5"
+
+kubectl apply -f "${RETURN_RESOURCE_MANIFEST}"
+
+kubectl wait --for=delete pod\
+    -n "$NAMESPACE" \
+    -l "$LABEL" \
+    --timeout=60s
+
+echo "All pods are deleted."

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
@@ -5,13 +5,11 @@
 set -Eeuo pipefail
 
 RETURN_RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/return-resource.yaml"
-NAMESPACE="gcp-symphony"
 RESOURCE_NAME="test-resource"
 
 kubectl apply -f "${RETURN_RESOURCE_MANIFEST}"
 
 kubectl wait --for=delete pod \
-    -n "$NAMESPACE" \
     -l "app=$RESOURCE_NAME" \
     --timeout=60s
 

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 
 RETURN_RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/return-resource.yaml"
 NAMESPACE="gcp-symphony"
-LABEL="app=test-resource-5"
+LABEL="app=test-resource"
 
 kubectl apply -f "${RETURN_RESOURCE_MANIFEST}"
 

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_integration.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-# Purpose:
+# Purpose: Validate that returning machines triggers pod termination
 # Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
 
 set -Eeuo pipefail
 
 RETURN_RESOURCE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/manifests/return-resource.yaml"
 NAMESPACE="gcp-symphony"
-LABEL="app=test-resource"
+RESOURCE_NAME="test-resource"
 
 kubectl apply -f "${RETURN_RESOURCE_MANIFEST}"
 
-kubectl wait --for=delete pod\
+kubectl wait --for=delete pod \
     -n "$NAMESPACE" \
-    -l "$LABEL" \
+    -l "app=$RESOURCE_NAME" \
     --timeout=60s
 
-echo "All pods are deleted."
+echo "[PASS] All pods successfully terminated after return request."

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_success_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_success_assert.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Purpose: Validate that machine return request completes successfully.
+# Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
+
+set -Eeuo pipefail
+
+NAMESPACE="gcp-symphony"
+RETURN_RESOURCE_NAME="test-return-request"
+
+MR_PHASE=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
+MR_RETURNED_MACHINES=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.returnedMachines}')
+MR_TOTAL_MACHINES=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.totalMachines}')
+
+if [[ $MR_PHASE != "Completed" || $MR_RETURNED_MACHINES != $MR_TOTAL_MACHINES ]]; then
+    echo "[FAIL] Machine return incomplete:"
+    echo " - Phase:             $MR_PHASE"
+    echo " - Returned machines: $MR_RETURNED_MACHINES"
+    echo " - Total machines:    $MR_TOTAL_MACHINES"
+    exit 1
+fi
+
+echo "[PASS] Machine return request completed successfully."

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_success_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_success_assert.sh
@@ -4,12 +4,13 @@
 
 set -Eeuo pipefail
 
-NAMESPACE="gcp-symphony"
 RETURN_RESOURCE_NAME="test-return-request"
 
-MR_PHASE=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
-MR_RETURNED_MACHINES=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.returnedMachines}')
-MR_TOTAL_MACHINES=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.totalMachines}')
+sleep 2
+
+MR_PHASE=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -o jsonpath='{.status.phase}')
+MR_RETURNED_MACHINES=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -o jsonpath='{.status.returnedMachines}')
+MR_TOTAL_MACHINES=$(kubectl get mrr "${RETURN_RESOURCE_NAME}" -o jsonpath='{.status.totalMachines}')
 
 if [[ $MR_PHASE != "Completed" || $MR_RETURNED_MACHINES != $MR_TOTAL_MACHINES ]]; then
     echo "[FAIL] Machine return incomplete:"

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_waitingcleanup_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_waitingcleanup_assert.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Purpose: Verify that symphony resource enters the WaitingCleanup phase after machine return.
+# Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
+
+set -Eeuo pipefail
+
+NAMESPACE="gcp-symphony"
+RESOURCE_NAME="test-resource"
+
+SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
+SR_STATUS=$(kubectl get gcpsr "${RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[-1].status}')
+SR_TYPE=$(kubectl get gcpsr "${RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[-1].type}')
+
+if [[ $SR_PHASE != "WaitingCleanup" || $SR_STATUS != "True" || $SR_TYPE != "Completed" ]]; then
+    echo "[FAIL] Resource state did not meet the requirements for cleanup."
+    echo "- Phase: $SR_PHASE"
+    echo "- Last condition status: $SR_STATUS"
+    echo "- Last condition type: $SR_TYPE"
+    exit 1
+fi
+
+echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_waitingcleanup_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_waitingcleanup_assert.sh
@@ -4,12 +4,11 @@
 
 set -Eeuo pipefail
 
-NAMESPACE="gcp-symphony"
 RESOURCE_NAME="test-resource"
 
-SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.phase}')
-SR_STATUS=$(kubectl get gcpsr "${RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[-1].status}')
-SR_TYPE=$(kubectl get gcpsr "${RESOURCE_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[-1].type}')
+SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
+SR_STATUS=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.conditions[-1].status}')
+SR_TYPE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.conditions[-1].type}')
 
 if [[ $SR_PHASE != "WaitingCleanup" || $SR_STATUS != "True" || $SR_TYPE != "Completed" ]]; then
     echo "[FAIL] Resource state did not meet the requirements for cleanup."


### PR DESCRIPTION
This PR adds a set of end-to-end integration tests for validating the machine lifecycle managed by the operator. The tests cover:
- Requesting machines and verifying pod creation
- Ensuring pods reach a healthy running state
- Returning machines and validating pod termination
- Confirming status transitions and completion states