### PR TITLE
chore: bump version 0.2.7 - 0.2.8 and update changelog

### DIFF
--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -18,6 +18,15 @@ A Kubernetes operator for managing GCP Symphony Hostfactory related resources.
 
 ## <a id="change-log"></a>Change log
 
+### Version 0.2.8
+- Added k8s-operator workflow
+- Updated all job runners to ubuntu-24.04 for more stable builds compared to ubuntu-latest.
+- Build images are now tagged as: k8s-operator:1.0.0-build.<run-number>.<first-7-characters-of-commit-hash>
+- Release images follow semantic versioning, e.g.: k8s-operator:1.0.0
+
+### Version 0.2.7
+- Fixed Failing Unit Tests
+
 ### Version 0.2.6
 - Added initial pod status check on operator startup to ensure existing pods are accounted
   for in status updates.

--- a/k8s-operator/pyproject.toml
+++ b/k8s-operator/pyproject.toml
@@ -20,7 +20,7 @@ description = "An operator for the IBM Spectrum Symphony hostfactory plugin for 
 name = "gcp-symphony-operator"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.2.7"
+version = "0.2.8"
 
 [project.optional-dependencies]
 dev = [

--- a/k8s-operator/src/gcp_symphony_operator/__init__.py
+++ b/k8s-operator/src/gcp_symphony_operator/__init__.py
@@ -1,3 +1,3 @@
 """GCP Symphony Kubernetes Operator"""
 
-__version__ = "0.2.6"
+__version__ = "0.2.8"


### PR DESCRIPTION
Bump version 0.2.7 to 0.2.8 and updated changelog

- [ /] Tests pass
- [/ ] Appropriate changes to documentation are included in the PR
