### PR TITLE
chore: deprecate preemption config, update docs and bump to 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This project provides two main components that work together to extend IBM Spect
 IBM Spectrum Symphony's Host Factory provides dynamic resource provisioning capabilities, but lacks native support for Google Cloud Platform. This project bridges that gap by:
 
 - **Enabling Cloud Bursting**: Allows Symphony clusters to dynamically scale into GCP when on-premises resources are insufficient
-- **Cost Optimization**: Leverages GCP's spot instances and preemptible VMs for cost-effective compute scaling  
 - **Unified Management**: Provides a consistent interface for managing both GKE pods and GCE instances through Symphony's existing Host Factory framework
 - **Enterprise Integration**: Seamlessly integrates with existing Symphony deployments without requiring architectural changes
 
@@ -93,7 +92,6 @@ The Host Factory Provider contains CLI tools that implement Symphony's Host Fact
 **Key Features:**
 - **Dual Provider Support**: Separate providers for GCE and GKE workloads
 - **Template-Based Provisioning**: Configurable resource templates aligned with Symphony requirements
-- **Spot Instance Support**: Cost optimization through preemptible VM usage
 - **Pub/Sub Integration**: Event-driven resource management for GCE instances
 
 **Documentation:**
@@ -108,14 +106,12 @@ The Kubernetes Operator manages Symphony compute pods within GKE clusters, handl
 **Key Features:**
 - **Custom Resource Definitions**: `GCPSymphonyResource` and `MachineReturnRequest` CRDs
 - **Asynchronous Operations**: High-performance async processing for large-scale deployments
-- **Preemption Handling**: Automatic detection and management of spot VM preemptions
 - **Resource Cleanup**: Automated cleanup of completed resources with configurable retention
 - **Health Monitoring**: Built-in health checks and status reporting
 
 **Documentation:**
 - [Operator README](k8s-operator/README.md) - Development setup and testing
 - [Configuration Guide](k8s-operator/docs/CONFIG.md) - Environment variables and tuning
-- [Quick Deploy Guide](k8s-operator/docs/QUICKDEPLOY.md) - Rapid deployment instructions
 - [Troubleshooting Guide](k8s-operator/docs/operator-troubleshooting-guide.md) - Comprehensive troubleshooting
 
 ## <a id="getting-started"></a>Getting Started

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project provides two main components that work together to extend IBM Spect
 IBM Spectrum Symphony's Host Factory provides dynamic resource provisioning capabilities, but lacks native support for Google Cloud Platform. This project bridges that gap by:
 
 - **Enabling Cloud Bursting**: Allows Symphony clusters to dynamically scale into GCP when on-premises resources are insufficient
+- **Cost Optimization**: Leverages GCP's spot instances and preemptible VMs for cost-effective compute scaling
 - **Unified Management**: Provides a consistent interface for managing both GKE pods and GCE instances through Symphony's existing Host Factory framework
 - **Enterprise Integration**: Seamlessly integrates with existing Symphony deployments without requiring architectural changes
 
@@ -92,6 +93,7 @@ The Host Factory Provider contains CLI tools that implement Symphony's Host Fact
 **Key Features:**
 - **Dual Provider Support**: Separate providers for GCE and GKE workloads
 - **Template-Based Provisioning**: Configurable resource templates aligned with Symphony requirements
+- **Spot Instance Support**: Cost optimization through preemptible VM usage
 - **Pub/Sub Integration**: Event-driven resource management for GCE instances
 
 **Documentation:**

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -18,6 +18,10 @@ A Kubernetes operator for managing GCP Symphony Hostfactory related resources.
 
 ## <a id="change-log"></a>Change log
 
+### Version 0.3.1
+- Commented out the preemption configuration in the operator code and added deprecation comments to guide optional manual enablement.
+- Removed preemption details from the configuration documentation.
+
 ### Version 0.3.0
 - Streamlined the k8s-operator workflow to utilize a single Docker build image throughout the entire execution cycle.
 - Implemented operator workflow integration tests, validation workflows (release, GCPSR/MRR/RMM CRDs, deployments, grace periods, cleanups), and health checks.

--- a/k8s-operator/docs/CONFIG.md
+++ b/k8s-operator/docs/CONFIG.md
@@ -41,9 +41,6 @@ This document outlines all user-adjustable environment variables for the GCP Sym
 | `GCP_HF_KUBERNETES_RBAC_CHECK` | `False` | Whether to check RBAC permissions on operator startup. |
 | `GCP_HF_KUBERNETES_CLIENT_TIMEOUT_ENABLE` | `False` | Whether to enable Kubernetes client timeout |
 | `GCP_HF_KUBERNETES_CLIENT_TIMEOUT` | `10` | Timeout for Kubernetes client operations (seconds) |
-| `GCP_HF_ENABLE_GKE_PREEMPTION_HANDLING` | `True` | Whether to enable the preemption handler to monitor for preemption of VMs. |
-| `GCP_HF_GKE_PREEMPT_LABELS` | `{"cloud.google.com/gke-spot": "true", "cloud.google.com/gke-provisioning": "spot"}` | A dictionary listing the node labels that indicate a VM is preemptable by the Google Compute Engine. Used when _ENABLE_GKE_PREEMPTION_HANDLING is set to True |
-| `GCP_HF_GKE_NODE_TAINTS_LIST` | `{"DeletionCandidateOfClusterAutoscaler", "node.cloudprovider.kubernetes.io/shutdown", "node.kubernetes.io/unschedulable"}` | A set of strings listing the possible TAINTS that GKE will apply to a node that is being preempted by Google Compute Engine. Used when _ENABLE_GKE_PREEMPTION_HANDLING is True. |
 
 ## Kopf Framework Configuration
 

--- a/k8s-operator/pyproject.toml
+++ b/k8s-operator/pyproject.toml
@@ -20,7 +20,7 @@ description = "An operator for the IBM Spectrum Symphony hostfactory plugin for 
 name = "gcp-symphony-operator"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.3.0"
+version = "0.3.1"
 
 [project.optional-dependencies]
 dev = [

--- a/k8s-operator/src/gcp_symphony_operator/__init__.py
+++ b/k8s-operator/src/gcp_symphony_operator/__init__.py
@@ -1,3 +1,3 @@
 """GCP Symphony Kubernetes Operator"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/k8s-operator/src/gcp_symphony_operator/config.py
+++ b/k8s-operator/src/gcp_symphony_operator/config.py
@@ -81,6 +81,13 @@ class Config:
 
     DEFAULT_ENABLE_GKE_PREEMPTION_HANDLING = False
     """
+    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+
+    This feature is deprecated and no longer recommended for active use. 
+    It has been commented out and removed from the official documentation. 
+    However, the underlying codebase still supports this feature; you can 
+    still enable it by uncommenting the configuration block if required.
+
     bool: Whether to enable GKE preemption handling.
     This will allow the operator to handle GKE VM preemption events.
     The behavior is to delete any pods on a node that are on an
@@ -183,6 +190,13 @@ class Config:
         "cloud.google.com/gke-provisioning": "spot"
     }
     """
+    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+
+    This feature is deprecated and no longer recommended for active use. 
+    It has been commented out and removed from the official documentation. 
+    However, the underlying codebase still supports this feature; you can 
+    still enable it by uncommenting the configuration block if required.
+
     dict: A dictionary of labels used to identify GKE VMs that may be subject to preemption.
     This is used to filter resources in the cluster.
     Default is {"cloud.google.com/gke-spot": "true", "cloud.google.com/gke-provisioning": "spot"}.
@@ -194,6 +208,13 @@ class Config:
         "node.kubernetes.io/unschedulable",
     }
     """
+    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+
+    This feature is deprecated and no longer recommended for active use. 
+    It has been commented out and removed from the official documentation. 
+    However, the underlying codebase still supports this feature; you can 
+    still enable it by uncommenting the configuration block if required.
+
     set: A set of taints used to identify nodes that are being preempted by the compute engine. These are only applied after passing the GKE_PREEMPT_LABELS filter.
     This is used to filter resources in the cluster.
     Default is {"DeletionCandidateOfClusterAutoscaler", "node.cloudprovider.kubernetes.io/shutdown", "node.kubernetes.io/unschedulable"}.
@@ -296,10 +317,17 @@ class Config:
             if self.kubernetes_client_timeout_enable
             else None
         )
-        self.enable_gke_preemption_handling = os.environ.get(
-            f"{self.env_var_prefix}ENABLE_GKE_PREEMPTION_HANDLING",
-            str(Config.DEFAULT_ENABLE_GKE_PREEMPTION_HANDLING),
-        ).lower() in ("true", "1", "yes")
+        
+        # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+        # This feature is deprecated and no longer recommended for active use. 
+        # It has been commented out and removed from the official documentation. 
+        # However, the underlying codebase still supports this feature; you can 
+        # still enable it by uncommenting this configuration block if required.
+        # self.enable_gke_preemption_handling = os.environ.get(
+        #     f"{self.env_var_prefix}ENABLE_GKE_PREEMPTION_HANDLING",
+        #     str(Config.DEFAULT_ENABLE_GKE_PREEMPTION_HANDLING),
+        # ).lower() in ("true", "1", "yes")
+
         self.kubeconfig_path = os.environ.get(
             f"{self.env_var_prefix}KUBECONFIG_PATH", Config.DEFAULT_KUBECONFIG_PATH
         )
@@ -590,15 +618,25 @@ class Config:
             f"{self.env_var_prefix}READINESS_CHECK_PATH",
             Config.DEFAULT_READINESS_CHECK_PATH,
         )
+        # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+        # This feature is deprecated and no longer recommended for active use. 
+        # It has been commented out and removed from the official documentation. 
+        # However, the underlying codebase still supports this feature; you can 
+        # still enable it by uncommenting this configuration block if required.
+        # self.gke_preempt_labels = os.environ.get(
+        #     f"{self.env_var_prefix}GKE_PREEMPT_LABELS",
+        #     Config.DEFAULT_GKE_PREEMPT_LABELS,
+        # )
 
-        self.gke_preempt_labels = os.environ.get(
-            f"{self.env_var_prefix}GKE_PREEMPT_LABELS",
-            Config.DEFAULT_GKE_PREEMPT_LABELS,
-        )
-        self.gke_node_taints_list = os.environ.get(
-            f"{self.env_var_prefix}GKE_NODE_TAINTS_LIST",
-            Config.DEFAULT_GKE_NODE_TAINTS_LIST,
-        )
+        # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+        # This feature is deprecated and no longer recommended for active use. 
+        # It has been commented out and removed from the official documentation. 
+        # However, the underlying codebase still supports this feature; you can 
+        # still enable it by uncommenting this configuration block if required.
+        # self.gke_node_taints_list = os.environ.get(
+        #     f"{self.env_var_prefix}GKE_NODE_TAINTS_LIST",
+        #     Config.DEFAULT_GKE_NODE_TAINTS_LIST,
+        # )
 
         if self.log_level == "DEBUG":
             # iterate over all config class attributes and log them

--- a/k8s-operator/src/gcp_symphony_operator/config.py
+++ b/k8s-operator/src/gcp_symphony_operator/config.py
@@ -81,12 +81,11 @@ class Config:
 
     DEFAULT_ENABLE_GKE_PREEMPTION_HANDLING = False
     """
-    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-
-    This feature is deprecated and no longer recommended for active use. 
-    It has been commented out and removed from the official documentation. 
-    However, the underlying codebase still supports this feature; you can 
-    still enable it by uncommenting the configuration block if required.
+    [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+    or taints to nodes that the operator can key on to identify when a node 
+    is being preempted. Without a reliable signal provided from the GCP 
+    infrastructure layer to the Kubernetes layer, this functionality is 
+    disabled by default as it provides no operational benefit.
 
     bool: Whether to enable GKE preemption handling.
     This will allow the operator to handle GKE VM preemption events.
@@ -190,12 +189,11 @@ class Config:
         "cloud.google.com/gke-provisioning": "spot"
     }
     """
-    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-
-    This feature is deprecated and no longer recommended for active use. 
-    It has been commented out and removed from the official documentation. 
-    However, the underlying codebase still supports this feature; you can 
-    still enable it by uncommenting the configuration block if required.
+    [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+    or taints to nodes that the operator can key on to identify when a node 
+    is being preempted. Without a reliable signal provided from the GCP 
+    infrastructure layer to the Kubernetes layer, this functionality is 
+    disabled by default as it provides no operational benefit.
 
     dict: A dictionary of labels used to identify GKE VMs that may be subject to preemption.
     This is used to filter resources in the cluster.
@@ -208,12 +206,11 @@ class Config:
         "node.kubernetes.io/unschedulable",
     }
     """
-    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-
-    This feature is deprecated and no longer recommended for active use. 
-    It has been commented out and removed from the official documentation. 
-    However, the underlying codebase still supports this feature; you can 
-    still enable it by uncommenting the configuration block if required.
+    [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+    or taints to nodes that the operator can key on to identify when a node 
+    is being preempted. Without a reliable signal provided from the GCP 
+    infrastructure layer to the Kubernetes layer, this functionality is 
+    disabled by default as it provides no operational benefit.
 
     set: A set of taints used to identify nodes that are being preempted by the compute engine. These are only applied after passing the GKE_PREEMPT_LABELS filter.
     This is used to filter resources in the cluster.
@@ -318,11 +315,11 @@ class Config:
             else None
         )
         
-        # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-        # This feature is deprecated and no longer recommended for active use. 
-        # It has been commented out and removed from the official documentation. 
-        # However, the underlying codebase still supports this feature; you can 
-        # still enable it by uncommenting this configuration block if required.
+        # [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+        # or taints to nodes that the operator can key on to identify when a node 
+        # is being preempted. Without a reliable signal provided from the GCP 
+        # infrastructure layer to the Kubernetes layer, this functionality is 
+        # disabled by default as it provides no operational benefit.
         # self.enable_gke_preemption_handling = os.environ.get(
         #     f"{self.env_var_prefix}ENABLE_GKE_PREEMPTION_HANDLING",
         #     str(Config.DEFAULT_ENABLE_GKE_PREEMPTION_HANDLING),
@@ -618,21 +615,21 @@ class Config:
             f"{self.env_var_prefix}READINESS_CHECK_PATH",
             Config.DEFAULT_READINESS_CHECK_PATH,
         )
-        # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-        # This feature is deprecated and no longer recommended for active use. 
-        # It has been commented out and removed from the official documentation. 
-        # However, the underlying codebase still supports this feature; you can 
-        # still enable it by uncommenting this configuration block if required.
+        # [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+        # or taints to nodes that the operator can key on to identify when a node 
+        # is being preempted. Without a reliable signal provided from the GCP 
+        # infrastructure layer to the Kubernetes layer, this functionality is 
+        # disabled by default as it provides no operational benefit.
         # self.gke_preempt_labels = os.environ.get(
         #     f"{self.env_var_prefix}GKE_PREEMPT_LABELS",
         #     Config.DEFAULT_GKE_PREEMPT_LABELS,
         # )
 
-        # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-        # This feature is deprecated and no longer recommended for active use. 
-        # It has been commented out and removed from the official documentation. 
-        # However, the underlying codebase still supports this feature; you can 
-        # still enable it by uncommenting this configuration block if required.
+        # [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+        # or taints to nodes that the operator can key on to identify when a node 
+        # is being preempted. Without a reliable signal provided from the GCP 
+        # infrastructure layer to the Kubernetes layer, this functionality is 
+        # disabled by default as it provides no operational benefit.
         # self.gke_node_taints_list = os.environ.get(
         #     f"{self.env_var_prefix}GKE_NODE_TAINTS_LIST",
         #     Config.DEFAULT_GKE_NODE_TAINTS_LIST,

--- a/k8s-operator/src/gcp_symphony_operator/handlers/preemption.py
+++ b/k8s-operator/src/gcp_symphony_operator/handlers/preemption.py
@@ -14,6 +14,12 @@ from gcp_symphony_operator.handlers.machine_return_request import process_pod_de
 
 def preemption_handler_factory(config, logger: Logger) -> Any:
     """
+    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+
+    This feature is deprecated and no longer recommended for active use. 
+    However, the underlying codebase still supports this feature; you can 
+    still enable it by uncommenting the configuration block if required.
+
     Factory function to create the preemption handler.
 
     Args:

--- a/k8s-operator/src/gcp_symphony_operator/handlers/preemption.py
+++ b/k8s-operator/src/gcp_symphony_operator/handlers/preemption.py
@@ -14,11 +14,11 @@ from gcp_symphony_operator.handlers.machine_return_request import process_pod_de
 
 def preemption_handler_factory(config, logger: Logger) -> Any:
     """
-    [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-
-    This feature is deprecated and no longer recommended for active use. 
-    However, the underlying codebase still supports this feature; you can 
-    still enable it by uncommenting the configuration block if required.
+    [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+    or taints to nodes that the operator can key on to identify when a node 
+    is being preempted. Without a reliable signal provided from the GCP 
+    infrastructure layer to the Kubernetes layer, this functionality is 
+    disabled by default as it provides no operational benefit.
 
     Factory function to create the preemption handler.
 

--- a/k8s-operator/src/gcp_symphony_operator/register_handlers.py
+++ b/k8s-operator/src/gcp_symphony_operator/register_handlers.py
@@ -56,11 +56,11 @@ def register_handlers(config: Config) -> None:
         machine_return_request.machine_return_request_handler_factory(config, logger)
     )
 
-    # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
-    # This feature is deprecated and no longer recommended for active use. 
-    # It has been commented out and removed from the official documentation. 
-    # However, the underlying codebase still supports this feature; you can 
-    # still enable it by uncommenting the configuration block if required.
+    # [DEPRECATED] This feature is deprecated because GKE does not apply labels 
+    # or taints to nodes that the operator can key on to identify when a node 
+    # is being preempted. Without a reliable signal provided from the GCP 
+    # infrastructure layer to the Kubernetes layer, this functionality is 
+    # disabled by default as it provides no operational benefit.
     # if config.enable_gke_preemption_handling:
         # from gcp_symphony_operator.handlers import preemption
         # _resource_handlers["preemption"] = preemption.preemption_handler_factory(

--- a/k8s-operator/src/gcp_symphony_operator/register_handlers.py
+++ b/k8s-operator/src/gcp_symphony_operator/register_handlers.py
@@ -56,10 +56,15 @@ def register_handlers(config: Config) -> None:
         machine_return_request.machine_return_request_handler_factory(config, logger)
     )
 
-    if config.enable_gke_preemption_handling:
-        from gcp_symphony_operator.handlers import preemption
-        _resource_handlers["preemption"] = preemption.preemption_handler_factory(
-            config, logger
-        )
+    # [DEPRECATED - NOT RECOMMENDED] Whether to enable preemption handling.
+    # This feature is deprecated and no longer recommended for active use. 
+    # It has been commented out and removed from the official documentation. 
+    # However, the underlying codebase still supports this feature; you can 
+    # still enable it by uncommenting the configuration block if required.
+    # if config.enable_gke_preemption_handling:
+        # from gcp_symphony_operator.handlers import preemption
+        # _resource_handlers["preemption"] = preemption.preemption_handler_factory(
+        #     config, logger
+        # )
 
     logger.info("All handlers registered successfully")


### PR DESCRIPTION
### Change-log
- Commented out the preemption configuration in the operator code and added deprecation comments to guide optional manual enablement.
- Removed preemption details from the configuration documentation.
- Bump version 0.3.0 -> 0.3.1

- [/] Tests pass
- [/] Appropriate changes to documentation are included in the PR
