### PR TITLE
Feat: GCPSymphonyResource partial return assertion

### DIFF
--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -18,7 +18,7 @@ A Kubernetes operator for managing GCP Symphony Hostfactory related resources.
 
 ## <a id="change-log"></a>Change log
 
-### Version 0.3.1
+### Version 0.3.2
 - Added integration test for partial machine return requests
 - Removed unnecessary assertion outputs and modified assertion logical conditions for better readability
 

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -18,6 +18,10 @@ A Kubernetes operator for managing GCP Symphony Hostfactory related resources.
 
 ## <a id="change-log"></a>Change log
 
+### Version 0.3.1
+- Added integration test for partial machine return requests
+- Removed unnecessary assertion outputs and modified assertion logical conditions for better readability
+
 ### Version 0.3.0
 - Streamlined the k8s-operator workflow to utilize a single Docker build image throughout the entire execution cycle.
 - Implemented operator workflow integration tests, validation workflows (release, GCPSR/MRR/RMM CRDs, deployments, grace periods, cleanups), and health checks.

--- a/k8s-operator/pyproject.toml
+++ b/k8s-operator/pyproject.toml
@@ -20,7 +20,7 @@ description = "An operator for the IBM Spectrum Symphony hostfactory plugin for 
 name = "gcp-symphony-operator"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.3.0"
+version = "0.3.1"
 
 [project.optional-dependencies]
 dev = [

--- a/k8s-operator/pyproject.toml
+++ b/k8s-operator/pyproject.toml
@@ -20,7 +20,7 @@ description = "An operator for the IBM Spectrum Symphony hostfactory plugin for 
 name = "gcp-symphony-operator"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.3.1"
+version = "0.3.2"
 
 [project.optional-dependencies]
 dev = [

--- a/k8s-operator/src/gcp_symphony_operator/__init__.py
+++ b/k8s-operator/src/gcp_symphony_operator/__init__.py
@@ -1,3 +1,3 @@
 """GCP Symphony Kubernetes Operator"""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/k8s-operator/src/gcp_symphony_operator/__init__.py
+++ b/k8s-operator/src/gcp_symphony_operator/__init__.py
@@ -1,3 +1,3 @@
 """GCP Symphony Kubernetes Operator"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/k8s-operator/tests/ci/kind-tests/test_gcpsr_partial_return_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_gcpsr_partial_return_assert.sh
@@ -34,7 +34,7 @@ kubectl wait --for=condition=Ready pod \
   -l "app=$RESOURCE_NAME" \
   --timeout=60s
 
-# Only return 1 out of 3 running pods
+# First partial machine return request by returning 1/3 running pods
 RETURN_RESOURCE="
 apiVersion: accenture.com/v1
 kind: MachineReturnRequest
@@ -58,7 +58,7 @@ MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.
 if [[ $MR_RETURNED_MACHINES == 1 && $MR_PHASE == "Completed" ]]; then
   echo "[PASS] First machine return request completed successfully."
 else
-  echo "[FAIL] Machine return incomplete:"
+  echo "[FAIL] First machine return request incomplete:"
   echo " - Phase:             ${MR_PHASE}"
   echo " - Returned machines: ${MR_RETURNED_MACHINES}"
   exit 1
@@ -77,16 +77,16 @@ if [[
   $SR_AVAILABLE_MACHINES == $POD_COUNT && \
   $SR_PHASE == "Running"
 ]]; then
-  echo "[PASS] First machine return request is successful and the gcpsr is consistent."
+  echo "[PASS] gcpsr is consistent after first machine return request."
 else
-  echo "[FAIL] Resources mismatch:"
+  echo "[FAIL] Resources mismatch  after first machine return request:"
   echo " - Requested machines: $SR_MACHINE_COUNT"
   echo " - Available machines: $SR_AVAILABLE_MACHINES"
   echo " - Running pods:       $POD_COUNT"
   exit 1
 fi
 
-# Return the remaining 2 running pods
+# Second partial machine return request by returning 2/3 remaining pods
 RETURN_RESOURCE="
 apiVersion: accenture.com/v1
 kind: MachineReturnRequest
@@ -105,8 +105,6 @@ kubectl wait --for=delete pod \
   -l "app=$RESOURCE_NAME" \
   --timeout=60s
 
-echo "[PASS] The remaining 2 pods successfully terminated after return request."
-
 sleep $SLEEP
 
 MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.phase}')
@@ -114,9 +112,9 @@ MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='
 MR_TOTAL_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.totalMachines}')
 
 if [[  $MR_PHASE == "Completed" && $MR_RETURNED_MACHINES == $MR_TOTAL_MACHINES ]]; then
-  echo "[PASS] Machine return request completed successfully."
+  echo "[PASS] Second machine return request completed successfully."
 else
-  echo "[FAIL] Machine return incomplete:"
+  echo "[FAIL] Second machine return request incomplete:"
   echo " - Phase:             ${MR_PHASE}"
   echo " - Returned machines: ${MR_RETURNED_MACHINES}"
   echo " - Total machines:    ${MR_TOTAL_MACHINES}"
@@ -134,9 +132,9 @@ if [[
   $SR_AVAILABLE_MACHINES == 0 && \
   $SR_AVAILABLE_MACHINES == $POD_COUNT \
 ]]; then
-  echo "[PASS] Second machine return request is successful and the gcpsr is consistent."
+  echo "[PASS] gcpsr is consistent after second machine return request."
 else
-  echo "[FAIL] Resources mismatch after cleanup:"
+  echo "[FAIL] Resources mismatch after second machine return request:"
   echo " - Requested machines: $SR_MACHINE_COUNT"
   echo " - Available machines: $SR_AVAILABLE_MACHINES"
   echo " - Running pods:       $POD_COUNT"

--- a/k8s-operator/tests/ci/kind-tests/test_gcpsr_partial_return_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_gcpsr_partial_return_assert.sh
@@ -3,6 +3,7 @@
 # Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
 set -Eeuo pipefail
 
+SLEEP=1
 RESOURCE_NAME="test-gcpsr-partial-return-assert"
 
 RESOURCE_MANIFESTS="
@@ -26,12 +27,12 @@ spec:
 kubectl apply -f - <<< "$RESOURCE_MANIFESTS"
 
 kubectl wait --for=create pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 kubectl wait --for=condition=Ready pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 # Only return 1 out of 3 running pods
 RETURN_RESOURCE="
@@ -49,23 +50,21 @@ kubectl apply -f - <<< "$RETURN_RESOURCE"
 
 kubectl wait --for=delete pod/$RESOURCE_NAME-pod-0 --timeout=60s
 
-echo "[PASS] $RESOURCE_NAME-pod-0 successfully terminated after return request."
-
-sleep 1
+sleep $SLEEP
 
 MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.phase}')
 MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.returnedMachines}')
 
-if [[ $MR_RETURNED_MACHINES != 1 || $MR_PHASE != "Completed" ]]; then
-    echo "[FAIL] Machine return incomplete:"
-    echo " - Phase:             ${MR_PHASE}"
-    echo " - Returned machines: ${MR_RETURNED_MACHINES}"
-    exit 1
+if [[ $MR_RETURNED_MACHINES == 1 && $MR_PHASE == "Completed" ]]; then
+  echo "[PASS] First machine return request completed successfully."
+else
+  echo "[FAIL] Machine return incomplete:"
+  echo " - Phase:             ${MR_PHASE}"
+  echo " - Returned machines: ${MR_RETURNED_MACHINES}"
+  exit 1
 fi
 
-echo "[PASS] One machine return request completed successfully."
-
-sleep 1
+sleep $SLEEP
 
 SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
 SR_MACHINE_COUNT=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.spec.machineCount}')
@@ -73,16 +72,18 @@ SR_AVAILABLE_MACHINES=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.stat
 POD_COUNT=$(kubectl get pods -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
 
 if [[ 
-    $SR_MACHINE_COUNT != 3 || \
-    $SR_AVAILABLE_MACHINES != 2 || \
-    $SR_AVAILABLE_MACHINES != $POD_COUNT || \
-    $SR_PHASE != "Running"
-]] then
-    echo "[FAIL] Resources mismatch:"
-    echo " - Requested machines: $SR_MACHINE_COUNT"
-    echo " - Available machines: $SR_AVAILABLE_MACHINES"
-    echo " - Running pods:       $POD_COUNT"
-    exit 1
+  $SR_MACHINE_COUNT == 3 && \
+  $SR_AVAILABLE_MACHINES == 2 && \
+  $SR_AVAILABLE_MACHINES == $POD_COUNT && \
+  $SR_PHASE == "Running"
+]]; then
+  echo "[PASS] First machine return request is successful and the gcpsr is consistent."
+else
+  echo "[FAIL] Resources mismatch:"
+  echo " - Requested machines: $SR_MACHINE_COUNT"
+  echo " - Available machines: $SR_AVAILABLE_MACHINES"
+  echo " - Running pods:       $POD_COUNT"
+  exit 1
 fi
 
 # Return the remaining 2 running pods
@@ -101,53 +102,53 @@ spec:
 kubectl apply -f - <<< "$RETURN_RESOURCE"
 
 kubectl wait --for=delete pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 echo "[PASS] The remaining 2 pods successfully terminated after return request."
 
-sleep 1
+sleep $SLEEP
 
 MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.phase}')
 MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.returnedMachines}')
 MR_TOTAL_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.totalMachines}')
 
-if [[  $MR_PHASE != "Completed" || $MR_RETURNED_MACHINES != $MR_TOTAL_MACHINES ]]; then
-    echo "[FAIL] Machine return incomplete:"
-    echo " - Phase:             ${MR_PHASE}"
-    echo " - Returned machines: ${MR_RETURNED_MACHINES}"
-    echo " - Total machines:    ${MR_TOTAL_MACHINES}"
-    exit 1
+if [[  $MR_PHASE == "Completed" && $MR_RETURNED_MACHINES == $MR_TOTAL_MACHINES ]]; then
+  echo "[PASS] Machine return request completed successfully."
+else
+  echo "[FAIL] Machine return incomplete:"
+  echo " - Phase:             ${MR_PHASE}"
+  echo " - Returned machines: ${MR_RETURNED_MACHINES}"
+  echo " - Total machines:    ${MR_TOTAL_MACHINES}"
+  exit 1
 fi
 
-echo "[PASS] Machine return request completed successfully."
-
-sleep 1
+sleep $SLEEP
 
 SR_MACHINE_COUNT=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.spec.machineCount}')
 SR_AVAILABLE_MACHINES=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.availableMachines}')
 POD_COUNT=$(kubectl get pods -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
 
 if [[ 
-    $SR_MACHINE_COUNT != 3 || \
-    $SR_AVAILABLE_MACHINES > 0 || \
-    $SR_AVAILABLE_MACHINES != $POD_COUNT \
-]] then
-    echo "[FAIL] Resources mismatch after cleanup:"
-    echo " - Requested machines: $SR_MACHINE_COUNT"
-    echo " - Available machines: $SR_AVAILABLE_MACHINES"
-    echo " - Running pods:       $POD_COUNT"
-    exit 1
+  $SR_MACHINE_COUNT == 3 && \
+  $SR_AVAILABLE_MACHINES == 0 && \
+  $SR_AVAILABLE_MACHINES == $POD_COUNT \
+]]; then
+  echo "[PASS] Second machine return request is successful and the gcpsr is consistent."
+else
+  echo "[FAIL] Resources mismatch after cleanup:"
+  echo " - Requested machines: $SR_MACHINE_COUNT"
+  echo " - Available machines: $SR_AVAILABLE_MACHINES"
+  echo " - Running pods:       $POD_COUNT"
+  exit 1
 fi
-
-echo "[PASS] All machines are returned and the gcpsr is consistent."
 
 SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
 
-if [ "$SR_PHASE" != "WaitingCleanup" ]; then
+if [ "$SR_PHASE" == "WaitingCleanup" ]; then
+  echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."
+else
   echo "[FAIL] Resource state did not meet the requirement for cleanup."
   echo "- Phase: $SR_PHASE"
   exit 1
 fi
-
-echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."

--- a/k8s-operator/tests/ci/kind-tests/test_gcpsr_partial_return_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_gcpsr_partial_return_assert.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Purpose: Validate that after a partial MachineReturnRequest removes only 1 pod, the GCPSymphonyResource remains active until the remaining pods are returned and transitions to WaitingCleanup phase.
+# Run from k8s-operator/tests/ci/kind-tests with an isolated Kubernetes context.
+set -Eeuo pipefail
+
+RESOURCE_NAME="test-gcpsr-partial-return-assert"
+
+RESOURCE_MANIFESTS="
+apiVersion: accenture.com/v1
+kind: GCPSymphonyResource
+metadata:
+  name: ${RESOURCE_NAME}
+  namespace: gcp-symphony
+  uid: test-uid-${RESOURCE_NAME}
+  labels:
+    symphony.requestId: ${RESOURCE_NAME}-request-id
+spec:
+  machineCount: 3
+  namePrefix: test
+  podSpec:
+    containers:
+    - name: base-pod
+      image: nginx:alpine
+"
+
+kubectl apply -f - <<< "$RESOURCE_MANIFESTS"
+
+kubectl wait --for=create pod \
+    -l "app=$RESOURCE_NAME" \
+    --timeout=60s
+
+kubectl wait --for=condition=Ready pod \
+    -l "app=$RESOURCE_NAME" \
+    --timeout=60s
+
+# Only return 1 out of 3 running pods
+RETURN_RESOURCE="
+apiVersion: accenture.com/v1
+kind: MachineReturnRequest
+metadata:
+  name: ${RESOURCE_NAME}-return
+  namespace: gcp-symphony
+spec:
+  requestId: ${RESOURCE_NAME}-return-request-id
+  machineIds:
+  - "${RESOURCE_NAME}-pod-0"
+"
+kubectl apply -f - <<< "$RETURN_RESOURCE"
+
+kubectl wait --for=delete pod/$RESOURCE_NAME-pod-0 --timeout=60s
+
+echo "[PASS] $RESOURCE_NAME-pod-0 successfully terminated after return request."
+
+sleep 1
+
+MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.phase}')
+MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.returnedMachines}')
+
+if [[ $MR_RETURNED_MACHINES != 1 || $MR_PHASE != "Completed" ]]; then
+    echo "[FAIL] Machine return incomplete:"
+    echo " - Phase:             ${MR_PHASE}"
+    echo " - Returned machines: ${MR_RETURNED_MACHINES}"
+    exit 1
+fi
+
+echo "[PASS] One machine return request completed successfully."
+
+sleep 1
+
+SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
+SR_MACHINE_COUNT=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.spec.machineCount}')
+SR_AVAILABLE_MACHINES=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.availableMachines}')
+POD_COUNT=$(kubectl get pods -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
+
+if [[ 
+    $SR_MACHINE_COUNT != 3 || \
+    $SR_AVAILABLE_MACHINES != 2 || \
+    $SR_AVAILABLE_MACHINES != $POD_COUNT || \
+    $SR_PHASE != "Running"
+]] then
+    echo "[FAIL] Resources mismatch:"
+    echo " - Requested machines: $SR_MACHINE_COUNT"
+    echo " - Available machines: $SR_AVAILABLE_MACHINES"
+    echo " - Running pods:       $POD_COUNT"
+    exit 1
+fi
+
+# Return the remaining 2 running pods
+RETURN_RESOURCE="
+apiVersion: accenture.com/v1
+kind: MachineReturnRequest
+metadata:
+  name: ${RESOURCE_NAME}-2-return
+  namespace: gcp-symphony
+spec:
+  requestId: ${RESOURCE_NAME}-2-return-request-id
+  machineIds:
+  - "${RESOURCE_NAME}-pod-1"
+  - "${RESOURCE_NAME}-pod-2"
+"
+kubectl apply -f - <<< "$RETURN_RESOURCE"
+
+kubectl wait --for=delete pod \
+    -l "app=$RESOURCE_NAME" \
+    --timeout=60s
+
+echo "[PASS] The remaining 2 pods successfully terminated after return request."
+
+sleep 1
+
+MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.phase}')
+MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.returnedMachines}')
+MR_TOTAL_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-2-return" -o jsonpath='{.status.totalMachines}')
+
+if [[  $MR_PHASE != "Completed" || $MR_RETURNED_MACHINES != $MR_TOTAL_MACHINES ]]; then
+    echo "[FAIL] Machine return incomplete:"
+    echo " - Phase:             ${MR_PHASE}"
+    echo " - Returned machines: ${MR_RETURNED_MACHINES}"
+    echo " - Total machines:    ${MR_TOTAL_MACHINES}"
+    exit 1
+fi
+
+echo "[PASS] Machine return request completed successfully."
+
+sleep 1
+
+SR_MACHINE_COUNT=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.spec.machineCount}')
+SR_AVAILABLE_MACHINES=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.availableMachines}')
+POD_COUNT=$(kubectl get pods -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
+
+if [[ 
+    $SR_MACHINE_COUNT != 3 || \
+    $SR_AVAILABLE_MACHINES > 0 || \
+    $SR_AVAILABLE_MACHINES != $POD_COUNT \
+]] then
+    echo "[FAIL] Resources mismatch after cleanup:"
+    echo " - Requested machines: $SR_MACHINE_COUNT"
+    echo " - Available machines: $SR_AVAILABLE_MACHINES"
+    echo " - Running pods:       $POD_COUNT"
+    exit 1
+fi
+
+echo "[PASS] All machines are returned and the gcpsr is consistent."
+
+SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
+
+if [ "$SR_PHASE" != "WaitingCleanup" ]; then
+  echo "[FAIL] Resource state did not meet the requirement for cleanup."
+  echo "- Phase: $SR_PHASE"
+  exit 1
+fi
+
+echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."

--- a/k8s-operator/tests/ci/kind-tests/test_pod_grace_period_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_pod_grace_period_assert.sh
@@ -77,11 +77,9 @@ ELAPSED=$((END - START))
 echo "Elapsed: ${ELAPSED} seconds"
 
 # assertion
-if [ "$ELAPSED" -ge 10 ] && [ "$ELAPSED" -le 120 ];
-then
+if [ "$ELAPSED" -ge 10 ] && [ "$ELAPSED" -le 120 ]; then
     echo "[PASS] Pod entered terminating state and respected the grace period."
-    exit 0
+else
+    echo "[FAIL] Pod did not respect the grace period. Elapsed time: ${ELAPSED} seconds."
+    exit 1
 fi
-
-echo "[FAIL] Pod did not respect the grace period. Elapsed time: ${ELAPSED} seconds."
-exit 1

--- a/k8s-operator/tests/ci/kind-tests/test_request_multiple_machines.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_multiple_machines.sh
@@ -26,12 +26,12 @@ spec:
 kubectl apply -f - <<< "$RESOURCE_MANIFESTS"
 
 kubectl wait --for=create pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 kubectl wait --for=condition=Ready pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 RETURN_RESOURCE="
 apiVersion: accenture.com/v1
@@ -50,10 +50,8 @@ spec:
 kubectl apply -f - <<< "$RETURN_RESOURCE"
 
 kubectl wait --for=delete pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
-
-echo "[PASS] All pods successfully terminated after return request."
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 sleep 1
 
@@ -61,22 +59,22 @@ MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.phase
 MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.returnedMachines}')
 MR_TOTAL_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.totalMachines}')
 
-if [[ $MR_PHASE != "Completed" || $MR_RETURNED_MACHINES != $MR_TOTAL_MACHINES ]]; then
-    echo "[FAIL] Machine return incomplete:"
-    echo " - Phase:             ${MR_PHASE}"
-    echo " - Returned machines: ${MR_RETURNED_MACHINES}"
-    echo " - Total machines:    ${MR_TOTAL_MACHINES}"
-    exit 1
+if [[ $MR_PHASE == "Completed" && $MR_RETURNED_MACHINES == $MR_TOTAL_MACHINES ]]; then
+  echo "[PASS] Machine return request completed successfully."
+else
+  echo "[FAIL] Machine return incomplete:"
+  echo " - Phase:             ${MR_PHASE}"
+  echo " - Returned machines: ${MR_RETURNED_MACHINES}"
+  echo " - Total machines:    ${MR_TOTAL_MACHINES}"
+  exit 1
 fi
-
-echo "[PASS] Machine return request completed successfully."
 
 SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
 
-if [ "$SR_PHASE" != "WaitingCleanup" ]; then
+if [ "$SR_PHASE" == "WaitingCleanup" ]; then
+  echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."
+else
   echo "[FAIL] Resource state did not meet the requirement for cleanup."
   echo "- Phase: $SR_PHASE"
   exit 1
 fi
-
-echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."

--- a/k8s-operator/tests/ci/kind-tests/test_request_resource_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_resource_assert.sh
@@ -65,3 +65,20 @@ if [[
 fi
 
 echo "[PASS] All machines are running and the resource state is consistent."
+
+RETURN_RESOURCE="
+apiVersion: accenture.com/v1
+kind: MachineReturnRequest
+metadata:
+  name: ${RESOURCE_NAME}-return
+  namespace: gcp-symphony
+spec:
+  requestId: ${RESOURCE_NAME}-return-request-id
+  machineIds:
+  - "${RESOURCE_NAME}-pod-0"
+"
+kubectl apply -f - <<< "$RETURN_RESOURCE"
+
+kubectl wait --for=delete pod \
+    -l "app=$RESOURCE_NAME" \
+    --timeout=60s

--- a/k8s-operator/tests/ci/kind-tests/test_request_resource_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_request_resource_assert.sh
@@ -33,8 +33,6 @@ kubectl wait --for=condition=Ready pod \
     -l "app=$RESOURCE_NAME" \
     --timeout=60s
 
-echo "[PASS] Resource request successfully created and initialized pods."
-
 for pod in $(kubectl get pods -l "app=${RESOURCE_NAME}" -o jsonpath='{.items[*].metadata.name}'); do
     STATUS=$(kubectl get pod "$pod" -o jsonpath='{.status.phase}')
 
@@ -52,10 +50,12 @@ SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
 POD_COUNT=$(kubectl get pods -l "app=${RESOURCE_NAME}" --no-headers | wc -l)
 
 if [[ 
-    $SR_MACHINE_COUNT != $SR_AVAILABLE_MACHINES || \
-    $SR_AVAILABLE_MACHINES != $POD_COUNT || \
-    $SR_PHASE != "Running" 
-]] then
+    $SR_MACHINE_COUNT == $SR_AVAILABLE_MACHINES && \
+    $SR_AVAILABLE_MACHINES == $POD_COUNT && \
+    $SR_PHASE == "Running" 
+]]; then
+    echo "[PASS] All machines are running and the resource state is consistent."
+else
     echo "[FAIL] Resources mismatch:"
     echo " - Requested machines: $SR_MACHINE_COUNT"
     echo " - Available machines: $SR_AVAILABLE_MACHINES"
@@ -63,8 +63,6 @@ if [[
     echo " - Resource phase:     $SR_PHASE"
     exit 1
 fi
-
-echo "[PASS] All machines are running and the resource state is consistent."
 
 RETURN_RESOURCE="
 apiVersion: accenture.com/v1

--- a/k8s-operator/tests/ci/kind-tests/test_return_machines_assert.sh
+++ b/k8s-operator/tests/ci/kind-tests/test_return_machines_assert.sh
@@ -26,12 +26,12 @@ spec:
 kubectl apply -f - <<< "$RESOURCE_MANIFESTS"
 
 kubectl wait --for=create pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 kubectl wait --for=condition=Ready pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 RETURN_RESOURCE="
 apiVersion: accenture.com/v1
@@ -47,10 +47,8 @@ spec:
 kubectl apply -f - <<< "$RETURN_RESOURCE"
 
 kubectl wait --for=delete pod \
-    -l "app=$RESOURCE_NAME" \
-    --timeout=60s
-
-echo "[PASS] All pods successfully terminated after return request."
+  -l "app=$RESOURCE_NAME" \
+  --timeout=60s
 
 sleep 1
 
@@ -58,22 +56,22 @@ MR_PHASE=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.phase
 MR_RETURNED_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.returnedMachines}')
 MR_TOTAL_MACHINES=$(kubectl get mrr "${RESOURCE_NAME}-return" -o jsonpath='{.status.totalMachines}')
 
-if [[ $MR_PHASE != "Completed" || $MR_RETURNED_MACHINES != $MR_TOTAL_MACHINES ]]; then
-    echo "[FAIL] Machine return incomplete:"
-    echo " - Phase:             ${MR_PHASE}"
-    echo " - Returned machines: ${MR_RETURNED_MACHINES}"
-    echo " - Total machines:    ${MR_TOTAL_MACHINES}"
-    exit 1
+if [[ $MR_PHASE == "Completed" && $MR_RETURNED_MACHINES == $MR_TOTAL_MACHINES ]]; then
+  echo "[PASS] Machine return request completed successfully."
+else
+  echo "[FAIL] Machine return incomplete:"
+  echo " - Phase:             ${MR_PHASE}"
+  echo " - Returned machines: ${MR_RETURNED_MACHINES}"
+  echo " - Total machines:    ${MR_TOTAL_MACHINES}"
+  exit 1
 fi
-
-echo "[PASS] Machine return request completed successfully."
 
 SR_PHASE=$(kubectl get gcpsr "${RESOURCE_NAME}" -o jsonpath='{.status.phase}')
 
-if [ "$SR_PHASE" != "WaitingCleanup" ]; then
+if [ "$SR_PHASE" == "WaitingCleanup" ]; then
+  echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."
+else
   echo "[FAIL] Resource state did not meet the requirement for cleanup."
   echo "- Phase: $SR_PHASE"
   exit 1
 fi
-
-echo "[PASS] Resource is in WaitingCleanup phase and ready for cleanup."


### PR DESCRIPTION
Added an integration test case for GCPSymphonyResource partial return assertion. This verifies GCPSR behavior when only a subset of pods is returned and the resource must remain active until the remaining pods are removed.

- [/] Tests pass
