### PR TITLE
fix: redirect stderr to prevent HostFactory JSON parse failures

### DIFF
--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getAvailableTemplates.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getAvailableTemplates.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce getAvailableTemplates -f $inJson
+$homeDir/bin/hf-gce getAvailableTemplates -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getRequestStatus.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getRequestStatus.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce getRequestStatus -f $inJson
+$homeDir/bin/hf-gce getRequestStatus -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getReturnRequests.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getReturnRequests.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce getReturnRequests -f $inJson
+$homeDir/bin/hf-gce getReturnRequests -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestMachines.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce requestMachines -f $inJson
+$homeDir/bin/hf-gce requestMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestReturnMachines.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestReturnMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce requestReturnMachines -f $inJson
+$homeDir/bin/hf-gce requestReturnMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getAvailableTemplates.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getAvailableTemplates.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke getAvailableTemplates -f $inJson
+$homeDir/bin/hf-gke getAvailableTemplates -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getRequestStatus.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getRequestStatus.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke getRequestStatus -f $inJson
+$homeDir/bin/hf-gke getRequestStatus -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getReturnRequests.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getReturnRequests.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke getReturnRequests -f $inJson
+$homeDir/bin/hf-gke getReturnRequests -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestMachines.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke requestMachines -f $inJson
+$homeDir/bin/hf-gke requestMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestReturnMachines.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestReturnMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke requestReturnMachines -f $inJson
+$homeDir/bin/hf-gke requestReturnMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"


### PR DESCRIPTION
**Problem**
The GCE and GKE provider shell scripts do not redirect stderr. Any output written to stderr from any source (e.g., deprecation warnings from third-party libraries) is included in the response passed to HostFactory, which expects clean JSON. This causes JSON parse failures and breaks the provider.

**Fix**
Redirect stderr to the existing provider log file. The path mirrors the one the Python provider already writes to, so stderr noise is captured alongside the structured logs operators already check:

- `HF_PROVIDER_LOGDIR` is the provider plugin's log directory
- `HF_PROVIDER_NAME` and `EGOSC_INSTANCE_HOST` are provided by HostFactory at script-invocation time and match the pattern in [hf-provider/src/gce_provider/config.py](https://github.com/google/symphony-gcp/blob/main/hf-provider/src/gce_provider/config.py#L78) and [hf-provider/src/gke_provider/config.py](https://github.com/google/symphony-gcp/blob/main/hf-provider/src/gke_provider/config.py#L43)

```bash
2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"
```

**Scope**
GCE and GKE providers.

**Verified at two levels:**

Script-level:
- Invoked the scripts manually and confirmed stdout contains only the JSON response.
- Confirmed the `FutureWarning` messages are now appended to the existing provider log instead of mixing into stdout.

End-to-end with the Cluster Management Console:
- Restarted HostFactory: `egosh service stop HostFactory` / `egosh service start HostFactory`.
- Connected to the management console and confirmed templates list correctly.
- Scheduled a machine request through the console.
- Returned the machines through the console.
- Confirmed the `FutureWarning` messages from these end-to-end invocations are appended to the existing provider log instead of mixing into stdout.

**Affected Files**

GCE:
- /gce_cli/1.2/providerplugins/gcpgce/scripts/getAvailableTemplates.sh
- /gce_cli/1.2/providerplugins/gcpgce/scripts/requestMachines.sh
- /gce_cli/1.2/providerplugins/gcpgce/scripts/requestReturnMachines.sh
- /gce_cli/1.2/providerplugins/gcpgce/scripts/getRequestStatus.sh
- /gce_cli/1.2/providerplugins/gcpgce/scripts/getReturnRequests.sh

GKE:
- /gke_cli/1.2/providerplugins/gcpgke/scripts/getAvailableTemplates.sh
- /gke_cli/1.2/providerplugins/gcpgke/scripts/requestMachines.sh
- /gke_cli/1.2/providerplugins/gcpgke/scripts/requestReturnMachines.sh
- /gke_cli/1.2/providerplugins/gcpgke/scripts/getRequestStatus.sh
- /gke_cli/1.2/providerplugins/gcpgke/scripts/getReturnRequests.sh

**Checklist**
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR

Fixes: #86