### PR TITLE
fix(logging): capture warnings for GCE and GKE providers

### DIFF
--- a/hf-provider/src/gce_provider/config.py
+++ b/hf-provider/src/gce_provider/config.py
@@ -84,7 +84,7 @@ HF_PROVIDER_LOGFILE = (
 )
 
 logging.getLogger(__name__)
-
+logging.captureWarnings(True)
 
 class Config:
     """Configuration class for the application."""

--- a/hf-provider/src/gke_provider/config.py
+++ b/hf-provider/src/gke_provider/config.py
@@ -46,6 +46,7 @@ HF_PROVIDER_LOGFILE = (
 )
 
 logging.getLogger(__name__)
+logging.captureWarnings(True)
 
 PROVIDER_CONF_GKE_KUBECONFIG = "GKE_KUBECONFIG"
 KUBECONFIG_DEFAULT_ENV = "KUBECONFIG"


### PR DESCRIPTION
**Problem**
Any output written to stderr from any source (e.g., deprecation warnings from third-party libraries) is included in the response passed to HostFactory, which expects clean JSON. This causes JSON parse failures and breaks the provider.

**Fix**
Call `logging.captureWarnings(True)` at module level in each provider's `config.py`. Once enabled, Python's `warnings` module routes warnings through the logging system instead of writing directly to `sys.stderr`. The result is no warning text leaking onto stderr, so the JSON response stays clean.

```python
# src/gce_provider/config.py and src/gke_provider/config.py
import logging
# ... existing module-level setup ...
logging.captureWarnings(True)
```

**Scope**
GCE and GKE providers.

**Verified at two levels:**

Script-level:
- Built the provider binaries from source against `google-auth==2.47.0` (versions that match `hf-gcpgce-provider-1.0.0-110.el10.x86_64`).
- Invoked the binary directly and confirmed no `FutureWarning` appears on stderr.
- Invoked the wrapper scripts and confirmed stdout contains only the JSON response.

End-to-end with the Cluster Management Console:
- Restarted HostFactory: `egosh service stop HostFactory` / `egosh service start HostFactory`.
- Connected to the management console and confirmed templates list correctly.
- Scheduled a machine request through the console.
- Returned the machines through the console.
- Confirmed no warning text leaks onto stderr during these end-to-end invocations.

**Affected Files**
- `hf-provider/src/gce_provider/config.py`
- `hf-provider/src/gke_provider/config.py`

**Checklist**
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR

Fixes: #86