### PR TITLE
fix(gce) correctly resolve and check credentials file path

### DIFF
--- a/hf-provider/src/gce_provider/utils/client_factory.py
+++ b/hf-provider/src/gce_provider/utils/client_factory.py
@@ -19,20 +19,21 @@ def get_credentials(
     if config is None:
         config = get_config()
 
-    if config.gcp_credentials_file and Path.exists(config.gcp_credentials_file):
+    if config.gcp_credentials_file:
         credentials_file_path = normalize_path(
             config.hf_provider_conf_dir, config.gcp_credentials_file
         )
 
-        try:
-            credentials_json = load_json_file(credentials_file_path)
-            return service_account.Credentials.from_service_account_info(
-                credentials_json
-            )
-        except Exception:
-            config.logger.error(
-                f"Unable to create service account credentials from file {credentials_file_path}"
-            )
+        if Path(credentials_file_path).exists():
+            try:
+                credentials_json = load_json_file(credentials_file_path)
+                return service_account.Credentials.from_service_account_info(
+                    credentials_json
+                )
+            except Exception as e:
+                config.logger.exception(
+                    f"Unable to create service account credentials from file {credentials_file_path}: {e}"
+                )
 
     logging.warning(
         "No credentials file defined, or file does not exist. Will rely on application default credentials."

--- a/hf-provider/tests/unit/gce_provider/test_client_factory.py
+++ b/hf-provider/tests/unit/gce_provider/test_client_factory.py
@@ -1,0 +1,81 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.oauth2 import service_account
+
+from gce_provider.config import Config
+from gce_provider.utils import client_factory
+
+
+@pytest.fixture(autouse=True)
+def clear_credentials_cache():
+    client_factory.get_credentials.cache_clear()
+
+
+def make_config(credentials_file, conf_dir):
+    config = MagicMock(spec=Config)
+    config.gcp_credentials_file = credentials_file
+    config.hf_provider_conf_dir = conf_dir
+    config.logger = MagicMock()
+    return config
+
+
+def test_returns_none_when_no_credentials_file():
+    """With no credentials file set, fall back to application default credentials."""
+    config = make_config(credentials_file=None, conf_dir="/some/dir")
+    assert client_factory.get_credentials(config) is None
+
+
+def test_uses_global_config_when_none_passed():
+    """When called with no config, load the global config via get_config()."""
+    with patch.object(client_factory, "get_config") as mock_get_config:
+        mock_get_config.return_value = make_config(
+            credentials_file=None, conf_dir="/some/dir"
+        )
+        result = client_factory.get_credentials(None)
+
+    assert result is None
+    mock_get_config.assert_called_once()
+
+
+def test_returns_none_when_file_missing(tmp_path):
+    """Configured-but-missing credentials file falls back to ADC (returns None)."""
+    config = make_config(credentials_file="missing_gcp_credentials_file.json", conf_dir=str(tmp_path))
+    assert client_factory.get_credentials(config) is None
+
+
+def test_resolves_relative_path_against_confdir(tmp_path):
+    """Relative credential path resolves against the provider config directory."""
+    sa_info = {"type": "service_account", "project_id": "test-project"}
+    creds = tmp_path / "test_gcp_credentials_file.json"
+    creds.write_text(json.dumps(sa_info))
+    config = make_config(credentials_file="test_gcp_credentials_file.json", conf_dir=str(tmp_path))
+
+    sentinel = object()
+    with patch.object(
+        service_account.Credentials,
+        "from_service_account_info",
+        return_value=sentinel,
+    ) as mock_from_info:
+       result = client_factory.get_credentials(config)
+
+    assert result is sentinel
+    mock_from_info.assert_called_once_with(sa_info)
+
+
+def test_falls_back_to_none_when_credential_load_fails(tmp_path):
+    """When GCP rejects the key file, swallow, log, and fall back to ADC (returns None)."""
+    creds = tmp_path / "test_gcp_credentials_file.json"
+    creds.write_text("{}")
+    config = make_config(credentials_file="test_gcp_credentials_file.json", conf_dir=str(tmp_path))
+
+    with patch.object(
+        service_account.Credentials,
+        "from_service_account_info",
+        side_effect=ValueError("bad key"),
+    ):
+        result = client_factory.get_credentials(config)
+
+    assert result is None
+    config.logger.exception.assert_called_once()


### PR DESCRIPTION
**Problem**
The GCE provider returns AttributeError 'str' object has no attribute 'stat' whenever an operator configures a service account key file instead of using the default automatic sign-in. 

`get_credentials()` checked the file with `Path.exists(config.gcp_credentials_file)`. This breaks `requestMachines`, `requestReturnMachines`, and the `hf-monitor` Pub/Sub listener. The default Application Default Credentials (ADC) path is unaffected because it leaves `GCP_CREDENTIALS_FILE` unset, so the broken branch is skipped.
 
**Fix**
Normalize the configured path first, then check that same normalized path with `Path(normalized_path).exists()`.
 
**Scope**
GCE provider (`hf-gce`) only. The GKE provider (`hf-gke`) signs in through a kubeconfig and is unaffected.
 
**Verified**
Management Console:
- `GCP_CREDENTIALS_FILE` pointed at the SA key.
- Created a machine request through the console and confirmed a VM is provisioned.
- Returned the machines through the console.
- Confirmed the provider log at `$HF_TOP/log/gcpgceinst-provider.*.log` shows no `AttributeError`.
 
**Unit tests**
- ADC fallback when no credentials file is set
- Configured-but-missing file falls back to ADC (this is the `'str' ... 'stat'` crash)
- Relative credentials path resolves against the provider config dir
- Load failure is swallowed, logged, and falls back to ADC
- Calling with no config resolves the global config via `get_config()`

**Affected files**
- hf-provider/src/gce_provider/utils/client_factory.py
- hf-provider/tests/unit/gce_provider/test_client_factory.py
 
**Checklist**
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
 
Fixes: #96