### PR TITLE
fix(logging): route warnings to provider log

### DIFF
--- a/hf-provider/src/common/log_bootstrap.py
+++ b/hf-provider/src/common/log_bootstrap.py
@@ -1,0 +1,183 @@
+import logging
+import logging.handlers
+import os
+import socket
+import tempfile
+from typing import Iterator, Optional
+
+
+ENV_HF_PROVIDER_NAME = "HF_PROVIDER_NAME"
+ENV_HF_PROVIDER_LOGDIR = "HF_PROVIDER_LOGDIR"
+ENV_EGOSC_INSTANCE_HOST = "EGOSC_INSTANCE_HOST"
+ENV_BOOTSTRAP_LOG_LEVEL = "GCP_HF_LOG_LEVEL"
+
+DEFAULT_HF_PROVIDER_NAME = "gcp-symphony"
+DEFAULT_LOG_LEVEL = "WARNING"
+DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+DEFAULT_LOG_BACKUP_COUNT = 5
+
+LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+
+# https://docs.python.org/3.9/library/logging.html#logging-levels
+_LEVEL_NAMES = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
+
+
+class _ProviderLogHandler(logging.handlers.RotatingFileHandler):
+    """Marker type for the handler this module manages on the root logger."""
+
+
+class _ProviderNullHandler(logging.NullHandler):
+    """Marker for the degraded mode where no log location is writable."""
+
+
+def _installed_handler() -> Optional[logging.Handler]:
+    """Return the handler installed on the root logger, if any."""
+    return next(
+        (
+            handler
+            for handler in logging.getLogger().handlers
+            if isinstance(handler, (_ProviderLogHandler, _ProviderNullHandler))
+        ),
+        None,
+    )
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname()
+    except Exception:
+        return "localhost"
+
+
+def _log_filename() -> str:
+    hf_provider_name = os.environ.get(ENV_HF_PROVIDER_NAME) or DEFAULT_HF_PROVIDER_NAME
+    hostname = os.environ.get(ENV_EGOSC_INSTANCE_HOST) or _hostname()
+    return f"{hf_provider_name}-provider.{hostname}.log"
+
+
+def _candidate_log_files() -> Iterator[str]:
+    filename = _log_filename()
+    log_dir = os.environ.get(ENV_HF_PROVIDER_LOGDIR)
+    if log_dir:
+        yield os.path.join(log_dir, filename)
+    yield os.path.join(tempfile.gettempdir(), filename)
+
+
+def default_log_file() -> str:
+    return next(_candidate_log_files())
+
+
+def _resolve_level(level: Optional[str]) -> int:
+    return _LEVEL_NAMES.get((level or DEFAULT_LOG_LEVEL).upper(), logging.WARNING)
+
+
+def _create_file_handler(
+        logfile: str, max_bytes: int, backup_count: int
+)-> Optional["_ProviderLogHandler"]:
+    try:
+        handler = _ProviderLogHandler(
+            filename=logfile, maxBytes=max_bytes, backupCount=backup_count
+        )
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        return handler
+    except (OSError, ValueError):
+        return None
+
+
+def _install_handler(handler: logging.Handler) -> None:
+    root_logger = logging.getLogger()
+    for existing_handler in list(root_logger.handlers):
+        if isinstance(existing_handler, (_ProviderLogHandler, _ProviderNullHandler)):
+            root_logger.removeHandler(existing_handler)
+            try:
+                existing_handler.close()
+            except Exception:
+                pass
+    root_logger.addHandler(handler)
+
+
+def bootstrap_logging() -> None:
+    """ Initialize logging for the provider. 
+    Must be called first before any third-party import.
+    """
+    if _installed_handler() is not None:
+        return
+    
+    logging.raiseExceptions = False
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(_resolve_level(os.environ.get(ENV_BOOTSTRAP_LOG_LEVEL)))
+
+    handler : Optional[logging.Handler] = None
+    for candidate_logfile in _candidate_log_files():
+        handler = _create_file_handler(
+            logfile=candidate_logfile,
+            max_bytes=DEFAULT_LOG_MAX_BYTES,
+            backup_count=DEFAULT_LOG_BACKUP_COUNT,
+        )
+        if handler is not None:
+            break
+    if handler is None:
+        handler = _ProviderNullHandler()
+
+    _install_handler(handler)
+    logging.captureWarnings(True)
+
+
+def configure_logging(
+    logfile: Optional[str] = None,
+    level: Optional[str] = None,
+    max_bytes: Optional[int] = None,
+    backup_count: Optional[int] = None
+) -> None:
+    """Re-apply log file, level, and rotation settings from the provider JSON configuration.
+
+    Args:
+        logfile: Path to the log file.
+        level: Logging level.
+        max_bytes: Maximum size of each log file.
+        backup_count: Number of backup log files to keep.
+    """
+    if _installed_handler() is None:
+        bootstrap_logging()
+
+    if level is not None:
+        logging.getLogger().setLevel(_resolve_level(level))
+    
+    if logfile is None:
+        return
+
+    target_max_bytes = DEFAULT_LOG_MAX_BYTES if max_bytes is None else max_bytes
+    target_backup_count = DEFAULT_LOG_BACKUP_COUNT if backup_count is None else backup_count
+
+    current_handler = _installed_handler()
+    # old one closed first
+    if (
+        
+        isinstance(current_handler, _ProviderLogHandler)
+        and os.path.abspath(current_handler.baseFilename) == os.path.abspath(logfile)
+        and current_handler.maxBytes == target_max_bytes
+        and current_handler.backupCount == target_backup_count
+    ):
+        return
+    
+    new_handler = _create_file_handler(
+        logfile=logfile,
+        max_bytes=target_max_bytes,
+        backup_count=target_backup_count,
+    )
+
+    if new_handler is None:
+        logging.getLogger(__name__).warning(
+            "Could not open configured log file %r, keeping the current log target",
+            logfile,
+        )
+        return
+    _install_handler(new_handler)

--- a/hf-provider/src/gce_provider/__main__.py
+++ b/hf-provider/src/gce_provider/__main__.py
@@ -1,9 +1,13 @@
 import argparse
 import json
+import logging
 import os
 import sys
 from argparse import Namespace
 from typing import Any, Callable, Optional
+
+from common.log_bootstrap import bootstrap_logging
+bootstrap_logging()
 
 from pydantic import BaseModel
 
@@ -32,6 +36,7 @@ from gce_provider.model.models import HFGceRequestMachines
 from gce_provider.pubsub import launch_pubsub_daemon, main as monitor_events
 from gce_provider.utils.constants import CommandNames
 
+logger = logging.getLogger(__name__)
 
 #   1. Before running this module,
 #      set up ADC as described in https://cloud.google.com/docs/authentication/external/set-up-adc
@@ -320,6 +325,7 @@ def main():
 
         sys.exit(0)
     except Exception as e:
+        logger.exception(f"Command failed: {e}")
         print(f"Error: {e}")
         sys.exit(1)
 

--- a/hf-provider/src/gce_provider/config.py
+++ b/hf-provider/src/gce_provider/config.py
@@ -1,14 +1,13 @@
 import logging
 import os
-import sys
 from functools import lru_cache
 
 from dotenv import load_dotenv
 from socket import gethostname
 
 import common.utils.path_utils as path_utils
+from common import log_bootstrap
 from common.utils.file_utils import load_json_file
-from logging.handlers import RotatingFileHandler
 
 # Load environment variables from .env file (if it exists)
 load_dotenv()
@@ -17,10 +16,8 @@ load_dotenv()
 ENV_VAR_PREFIX = "GCP_HF_"
 
 # Environment vars set by HostFactory
-ENV_EGOSC_INSTANCE_HOST = "EGOSC_INSTANCE_HOST"
 ENV_HF_DBDIR = "HF_DBDIR"
 ENV_HF_PROVIDER_CONFDIR = "HF_PROVIDER_CONFDIR"
-ENV_HF_PROVIDER_LOGDIR = "HF_PROVIDER_LOGDIR"
 ENV_HF_PROVIDER_NAME = "HF_PROVIDER_NAME"
 
 
@@ -70,20 +67,6 @@ ENV_PLUGIN_DB_FILENAME = prepend_env_var("DB_FILENAME")
 ENV_PLUGIN_CONFIG_FILENAME = prepend_env_var("CONFIG_FILENAME")
 
 HF_PROVIDER_NAME = os.environ.get(ENV_HF_PROVIDER_NAME, DEFAULT_HF_PROVIDER_NAME)
-HF_PROVIDER_LOGDIR = os.environ.get(
-    ENV_HF_PROVIDER_LOGDIR,
-    os.path.dirname(sys.argv[0]),  # default to directory of the binary
-)
-EGOSC_INSTANCE_HOST = os.environ.get(ENV_EGOSC_INSTANCE_HOST)
-HF_PROVIDER_LOGFILE = (
-    os.path.join(
-        HF_PROVIDER_LOGDIR, f"{HF_PROVIDER_NAME}-provider.{EGOSC_INSTANCE_HOST}.log"
-    )
-    if HF_PROVIDER_LOGDIR
-    else None
-)
-
-logging.getLogger(__name__)
 
 
 class Config:
@@ -122,15 +105,20 @@ class Config:
             )
 
         # configure logging. This should occur before any log entries are emitted
-        self.hf_provider_log_file = hf_provider_conf.get(
-            CONFIG_VAR_LOGFILE, HF_PROVIDER_LOGFILE
+        self.hf_provider_log_file = (
+            hf_provider_conf.get(CONFIG_VAR_LOGFILE) or log_bootstrap.default_log_file()
         )
         self.log_level = hf_provider_conf.get(CONFIG_VAR_LOG_LEVEL, DEFAULT_LOG_LEVEL)
-
-        logging.basicConfig(
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            filename=self.hf_provider_log_file,
-            level=self.log_level.upper() if self.log_level else DEFAULT_LOG_LEVEL,
+        
+        log_bootstrap.configure_logging(
+            logfile=str(self.hf_provider_log_file),
+            level=self.log_level,
+            max_bytes=int(
+                hf_provider_conf.get(CONFIG_VAR_LOG_MAX_FILE_SIZE, DEFAULT_LOG_MAX_FILE_SIZE)
+            ) * 1024 * 1024,  # nth MB in bytes
+            backup_count=int(
+                hf_provider_conf.get(CONFIG_VAR_LOG_MAX_ROTATE, DEFAULT_LOG_MAX_ROTATE)
+            )
         )
         self.logger = logging.getLogger(__name__)
 
@@ -214,35 +202,6 @@ class Config:
                 CONFIG_VAR_PUBSUB_AUTOLAUNCH, DEFAULT_PUBSUB_AUTOLAUNCH
             )
         )
-
-        # configure logging
-        self.hf_provider_log_file = hf_provider_conf.get(
-            CONFIG_VAR_LOGFILE, HF_PROVIDER_LOGFILE
-        )
-        self.log_level = hf_provider_conf.get(CONFIG_VAR_LOG_LEVEL, DEFAULT_LOG_LEVEL)
-
-        # Create rotating handler (append by default)
-        handler = RotatingFileHandler(
-            filename=str(self.hf_provider_log_file),
-            maxBytes=int(
-                hf_provider_conf.get(CONFIG_VAR_LOG_MAX_FILE_SIZE, DEFAULT_LOG_MAX_FILE_SIZE)
-            ) * 1024 * 1024,  # nth MB in bytes
-            backupCount=hf_provider_conf.get(
-                CONFIG_VAR_LOG_MAX_ROTATE, DEFAULT_LOG_MAX_ROTATE
-            )
-        )
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s",
-        )
-        handler.setFormatter(formatter)
-
-        logging.basicConfig(
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            filename=self.hf_provider_log_file,
-            level=self.log_level.upper() if self.log_level else DEFAULT_LOG_LEVEL,
-        )
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(handler)
 
         # iterate over the class attributes and log them
         if self.log_level.upper() == "DEBUG":

--- a/hf-provider/src/gce_provider/pubsub.py
+++ b/hf-provider/src/gce_provider/pubsub.py
@@ -5,6 +5,9 @@ import sys
 from concurrent.futures import TimeoutError
 from pprint import pprint
 
+from common.log_bootstrap import bootstrap_logging
+bootstrap_logging()
+
 import google.cloud.pubsub_v1 as pubsub
 
 from gce_provider.config import get_config

--- a/hf-provider/src/gke_provider/__main__.py
+++ b/hf-provider/src/gke_provider/__main__.py
@@ -1,8 +1,12 @@
 import argparse
 import json
+import logging
 import os
 import sys
 from typing import Any, Dict, Optional
+
+from common.log_bootstrap import bootstrap_logging
+bootstrap_logging()
 
 from typing_extensions import Self
 
@@ -19,6 +23,8 @@ from gke_provider.commands.get_return_requests import get_return_requests
 from gke_provider.commands.request_machines import request_machines
 from gke_provider.commands.request_return_machines import request_return_machines
 from gke_provider.config import get_config
+
+logger = logging.getLogger(__name__)
 
 # Initialize configuration
 config = get_config()
@@ -231,9 +237,8 @@ def dispatch_command(command: str, payload: Optional[dict]):
             print(output)
             return
         else:
-            config.logger.info(f"DISPATCHING|command: {command}; ERROR: empty result")
-            print("ERROR: Command returned empty result")
-            return
+            config.logger.error(f"DISPATCHING|command: {command}; ERROR: empty result")
+            raise RuntimeError(f"Command {command} returned no result")
     else:
         raise Exception(f"Invalid command: {cmd}")
 
@@ -283,6 +288,7 @@ def main() -> int:
         dispatch_command(command, payload)
         sys.exit(0)
     except Exception as e:
+        logger.exception(f"Command failed: {e}")
         print(f"Error: {e}")
         sys.exit(1)
 

--- a/hf-provider/src/gke_provider/config.py
+++ b/hf-provider/src/gke_provider/config.py
@@ -6,8 +6,8 @@ from socket import gethostname
 from dotenv import load_dotenv
 
 import common.utils.path_utils as path_utils
+from common import log_bootstrap
 from common.utils.file_utils import load_json_file
-from logging.handlers import RotatingFileHandler
 
 # Load environment variables from .env file (if it exists)
 load_dotenv()
@@ -37,15 +37,6 @@ DEFAULT_HF_PROVIDER_NAME = "gcp-symphony"
 
 HF_PROVIDER_NAME = os.environ.get("HF_PROVIDER_NAME", DEFAULT_HF_PROVIDER_NAME)
 HF_PROVIDER_CONFDIR_ENV = "HF_PROVIDER_CONFDIR"
-HF_PROVIDER_LOGDIR = os.environ.get("HF_PROVIDER_LOGDIR")
-EGOSC_INSTANCE_HOST = os.environ.get("EGOSC_INSTANCE_HOST")
-HF_PROVIDER_LOGFILE = (
-    os.path.join(HF_PROVIDER_LOGDIR, f"{HF_PROVIDER_NAME}-provider.{EGOSC_INSTANCE_HOST}.log")
-    if HF_PROVIDER_LOGDIR
-    else None
-)
-
-logging.getLogger(__name__)
 
 PROVIDER_CONF_GKE_KUBECONFIG = "GKE_KUBECONFIG"
 KUBECONFIG_DEFAULT_ENV = "KUBECONFIG"
@@ -56,6 +47,8 @@ class Config:
 
     def __init__(self) -> None:
         """Load configuration values from environment"""
+        self.logger = logging.getLogger(__name__)
+
         self.hf_provider_name = HF_PROVIDER_NAME
 
         self.hf_provider_conf_dir: str = os.environ.get(HF_PROVIDER_CONFDIR_ENV, "")
@@ -135,31 +128,21 @@ class Config:
             hf_provider_conf.get("GKE_POLLING_INTERVAL", DEFAULT_POLLING_INTERVAL)
         )
         # This allows the user to override the default HF log directory/filename
-        self.hf_provider_log_file = hf_provider_conf.get("LOGFILE", HF_PROVIDER_LOGFILE)
+        self.hf_provider_log_file = (
+            hf_provider_conf.get("LOGFILE") or log_bootstrap.default_log_file()
+        )
         self.log_level = hf_provider_conf.get("LOG_LEVEL", DEFAULT_LOG_LEVEL)
 
-        # Create rotating handler (append by default)
-        handler = RotatingFileHandler(
-            filename=str(self.hf_provider_log_file),
-            maxBytes=int(
+        log_bootstrap.configure_logging(
+            logfile=str(self.hf_provider_log_file),
+            level=self.log_level,
+            max_bytes=int(
                 hf_provider_conf.get("LOG_MAX_FILE_SIZE", DEFAULT_LOG_MAX_FILE_SIZE)
             ) * 1024 * 1024,  # nth MB in bytes
-            backupCount=hf_provider_conf.get(
-                "LOG_MAX_ROTATE", DEFAULT_LOG_MAX_ROTATE
+            backup_count=int(
+                hf_provider_conf.get("LOG_MAX_ROTATE", DEFAULT_LOG_MAX_ROTATE)
             )
         )
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s",
-        )
-        handler.setFormatter(formatter)
-
-        logging.basicConfig(
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            filename=self.hf_provider_log_file,
-            level=self.log_level.upper() if self.log_level else DEFAULT_LOG_LEVEL,
-        )
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(handler)
 
         # iterate over the class attributes and log them
         if self.log_level.upper() == "DEBUG":

--- a/hf-provider/tests/unit/common/test_log_bootstrap.py
+++ b/hf-provider/tests/unit/common/test_log_bootstrap.py
@@ -1,0 +1,200 @@
+import json
+import logging
+import logging.handlers
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import warnings
+
+import pytest
+
+from common import log_bootstrap
+
+def _remove_managed_handlers():
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        if isinstance(
+            handler,
+            (log_bootstrap._ProviderLogHandler, log_bootstrap._ProviderNullHandler),
+        ):
+            root_logger.removeHandler(handler)
+            handler.close()
+    logging.captureWarnings(False)
+    
+
+@pytest.fixture(autouse=True)
+def isolate_root_logger():
+    """Isolate the root logger for each test"""
+    _remove_managed_handlers()
+    yield
+    _remove_managed_handlers()
+
+
+def test_default_log_file_honors_hostfactory_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    monkeypatch.setenv("HF_PROVIDER_NAME", "myprovider")
+    monkeypatch.setenv("EGOSC_INSTANCE_HOST", "testhost")
+
+    assert log_bootstrap.default_log_file() == str(
+        tmp_path / "myprovider-provider.testhost.log"
+    )
+
+
+def test_default_log_file_falls_back_to_hostname(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    monkeypatch.delenv("HF_PROVIDER_NAME", raising=False)
+    monkeypatch.delenv("EGOSC_INSTANCE_HOST", raising=False)
+
+    expected = f"gcp-symphony-provider.{socket.gethostname()}.log"
+    assert os.path.basename(log_bootstrap.default_log_file()) == expected
+
+
+def test_default_log_file_matches_wrapper_script_fallback(monkeypatch):
+    monkeypatch.delenv("HF_PROVIDER_LOGDIR", raising=False)
+
+    assert os.path.dirname(log_bootstrap.default_log_file()) == tempfile.gettempdir()
+
+
+def test_bootstrap_routes_warnings_to_log_not_stderr(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    monkeypatch.setenv("EGOSC_INSTANCE_HOST", "testhost")
+    monkeypatch.delenv("HF_PROVIDER_NAME", raising=False)
+
+    log_bootstrap.bootstrap_logging()
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        warnings.warn("synthetic-runtime-warning", FutureWarning)
+    log_bootstrap._installed_handler().flush()
+
+    log_file_path = tmp_path / "gcp-symphony-provider.testhost.log"
+    assert "synthetic-runtime-warning" in log_file_path.read_text()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+def test_bootstrap_is_idempotent(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    root_logger = logging.getLogger()
+    handlers_before = len(root_logger.handlers)
+
+    log_bootstrap.bootstrap_logging()
+    log_bootstrap.bootstrap_logging()
+
+    assert len(root_logger.handlers) == handlers_before + 1
+
+
+def test_bootstrap_falls_back_to_tempdir(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path / "nonexistent_dir"))
+    fallback_dir = tmp_path / "tempdir"
+    fallback_dir.mkdir()
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_dir))
+
+    log_bootstrap.bootstrap_logging()
+
+    handler = log_bootstrap._installed_handler()
+    assert isinstance(handler, logging.handlers.RotatingFileHandler)
+    assert os.path.dirname(handler.baseFilename) == str(fallback_dir)
+
+
+def test_bootstrap_never_attaches_stream_handler(monkeypatch, tmp_path):
+    missing = tmp_path / "missing"
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(missing / "logs"))
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(missing / "tmp"))
+    
+    root_logger = logging.getLogger()
+    handlers_before  = list(root_logger.handlers)
+    log_bootstrap.bootstrap_logging()
+
+    added_handlers = [handler for handler in root_logger.handlers if handler not in handlers_before]
+    assert len(added_handlers) == 1
+    assert isinstance(added_handlers[0], logging.NullHandler)
+
+def test_bootstrap_reinstalls_after_external_handler_removal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+
+    root_logger = logging.getLogger()
+    root_logger.removeHandler(log_bootstrap._installed_handler())
+    assert log_bootstrap._installed_handler() is None
+
+    log_bootstrap.bootstrap_logging()
+    assert log_bootstrap._installed_handler() is not None
+
+
+def test_configure_logging_applies_provider_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+
+    custom_logfile = tmp_path / "custom.log"
+    log_bootstrap.configure_logging(
+        logfile=str(custom_logfile), level="INFO", max_bytes=1024, backup_count=2
+    )
+
+    assert logging.getLogger().level == logging.INFO
+    handler = log_bootstrap._installed_handler()
+    assert os.path.abspath(handler.baseFilename) == os.path.abspath(str(custom_logfile))
+
+    logging.getLogger("contract.test").info("test-info-message")
+    handler.flush()
+    assert "test-info-message" in custom_logfile.read_text()
+
+
+def test_configure_logging_reuses_handler_when_unchanged(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+    handler = log_bootstrap._installed_handler()
+
+    log_bootstrap.configure_logging(
+        logfile=log_bootstrap.default_log_file(),
+        level="WARNING",
+        max_bytes=log_bootstrap.DEFAULT_LOG_MAX_BYTES,
+        backup_count=log_bootstrap.DEFAULT_LOG_BACKUP_COUNT
+    )
+
+    assert log_bootstrap._installed_handler() is handler
+
+
+def test_configure_logging_keeps_old_target_when_new_unwritable(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+    old_handler = log_bootstrap._installed_handler()
+
+    log_bootstrap.configure_logging(logfile=str(tmp_path / "missing" / "x.log"))
+
+    assert log_bootstrap._installed_handler() is old_handler
+
+
+def test_import_time_warning_is_captured_end_to_end(tmp_path, src_dir):
+    script = "\n".join(
+        [
+            "from common.log_bootstrap import bootstrap_logging",
+            "bootstrap_logging()",
+            "import warnings",
+            "warnings.warn('synthetic-import-time-warning', FutureWarning)",
+            'print(\'{"ok": true}\')'
+        ]
+    )
+    env = os.environ.copy()
+
+    env.pop("HF_PROVIDER_NAME", None)
+    env.pop("GCP_HF_LOG_LEVEL", None)
+    env["HF_PROVIDER_LOGDIR"] = str(tmp_path)
+    env["EGOSC_INSTANCE_HOST"] = "e2ehost"
+    env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    env["PYTHONWARNINGS"] = "always"
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert json.loads(result.stdout) == {"ok": True}
+    assert result.stderr == ""
+    log_content = (tmp_path / "gcp-symphony-provider.e2ehost.log").read_text()
+    assert "synthetic-import-time-warning" in log_content

--- a/hf-provider/tests/unit/conftest.py
+++ b/hf-provider/tests/unit/conftest.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+
+import pytest
+
+_HF_PROVIDER_ROOT = Path(__file__).parents[2]
+_CONTRACT_HOST = "contract-host"
+
+
+
+@pytest.fixture
+def src_dir() -> Path:
+    return _HF_PROVIDER_ROOT / "src"
+
+
+@pytest.fixture
+def provider_config_dir() -> Path:
+    return (
+        _HF_PROVIDER_ROOT
+        / "tests"
+        / "resources"
+        / "provider-config"
+        / "config-001"
+        / "conf"
+        / "providers"
+    )
+
+
+@pytest.fixture
+def provider_log_name() -> str:
+    return f"gcp-symphony-provider.{_CONTRACT_HOST}.log"
+
+
+@pytest.fixture
+def make_cli_env(src_dir):
+
+    def _make(confdir, log_dir):
+        env = os.environ.copy()
+
+        env.pop("HF_PROVIDER_NAME", None)
+        env.pop("GCP_HF_LOG_LEVEL", None)
+        env["HF_PROVIDER_CONFDIR"] = str(confdir)
+        env["HF_PROVIDER_LOGDIR"] = str(log_dir)
+        env["EGOSC_INSTANCE_HOST"] = _CONTRACT_HOST
+        env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+        env["PYTHONWARNINGS"] = "always"
+
+        return env
+    
+    return _make

--- a/hf-provider/tests/unit/gce_provider/test_stdout_contract.py
+++ b/hf-provider/tests/unit/gce_provider/test_stdout_contract.py
@@ -1,0 +1,61 @@
+import json
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+
+@pytest.fixture
+def gce_cli_env(tmp_path, make_cli_env, provider_config_dir):
+    conf_dir = tmp_path / "conf"
+    shutil.copytree(provider_config_dir / "gcpgceinst", conf_dir)
+    config_path = conf_dir / "gcpgceinstprov_config.json"
+    provider_conf = json.loads(config_path.read_text())
+    provider_conf["PUBSUB_AUTOLAUNCH"] = False
+    config_path.write_text(json.dumps(provider_conf))
+
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    env = make_cli_env(conf_dir, log_dir)
+    env["HF_DBDIR"] = str(db_dir)
+    return env, log_dir
+
+
+def test_get_available_templates_is_pure_json(gce_cli_env, provider_log_name):
+    env, log_dir = gce_cli_env
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gce_provider", "getAvailableTemplates"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    parsed = json.loads(result.stdout)
+    assert "templates" in parsed
+    assert result.stderr == ""
+    assert (log_dir / provider_log_name).exists()
+
+
+def test_failure_exits_1_with_error_message_on_stdout(gce_cli_env, provider_log_name):
+    env, log_dir = gce_cli_env
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gce_provider", "requestMachines", "{}"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert result.stdout.startswith("Error:")
+    assert result.stderr == ""
+    assert "Traceback" in (log_dir / provider_log_name).read_text()

--- a/hf-provider/tests/unit/gke_provider/test_stdout_contract.py
+++ b/hf-provider/tests/unit/gke_provider/test_stdout_contract.py
@@ -1,0 +1,41 @@
+import json
+import subprocess
+import sys
+
+def test_get_available_templates_stdout_is_pure_json(
+    tmp_path, make_cli_env, provider_config_dir, provider_log_name
+):
+    env = make_cli_env(provider_config_dir / "gcpgkeinst", tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gke_provider", "getAvailableTemplates"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    parsed = json.loads(result.stdout)
+    assert "templates" in parsed
+    assert result.stderr == ""
+    assert (tmp_path / provider_log_name).exists()
+
+
+def test_failure_exits_1_with_error_message_on_stdout(
+        tmp_path, make_cli_env, provider_config_dir, provider_log_name
+):
+    env = make_cli_env(provider_config_dir / "gcpgkeinst", tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gke_provider", "requestMachines", "{}"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert result.stdout.startswith("Error:")
+    assert result.stderr == ""
+    assert "Traceback" in (tmp_path / provider_log_name).read_text()


### PR DESCRIPTION
**Problem**
Warnings emitted by third-party libraries (e.g., the `google-auth` `FutureWarning` on Python 3.9) are written to stderr at import time and end up mixed into the response passed to HostFactory, which expects clean JSON on stdout. This causes JSON parse failures and breaks the provider.

Complements #92 , which redirects the wrapper scripts' stderr into the provider log.  #92  covers output Python cannot intercept (native/C-level stderr from grpc, anything emitted before the interpreter reaches the entry module), while this PR captures Python-level warnings at the source and guarantees the providers' own logging can never target stderr. 

**Fix**

- Add `common/log_bootstrap.py`. It attaches a single rotating file handler to the root logger and enables `logging.captureWarnings` so `warnings.warn` output is logged instead of written to stderr. The log path resolves from the same HostFactory variables the wrapper scripts use (`HF_PROVIDER_LOGDIR`, `HF_PROVIDER_NAME`, `EGOSC_INSTANCE_HOST`, with hostname as a fallback), and falls back to the system temp dir mirroring #92 so both the wrapper layer and the Python layer write to the same file. If no location is writable, it degrades to a `NullHandler` rather than ever attaching a stream handler.
- Call `bootstrap_logging()` first in all three entry points (`hf-gce`, `hf-gke`, `hf-monitor`), before any third-party import, so import-time warnings are captured.
- `Config` in both providers now delegates to `log_bootstrap.configure_logging(...)`, which re-applies the log file, level, and rotation limits from the provider JSON. This removes the previous duplicated `basicConfig` + `addHandler` setup, which had three problems: every record was written twice, the same file was rotated by two handlers at once, and when `HF_PROVIDER_LOGDIR` was unset it attached a stderr stream handler and created a file literally named `None`.
- Failure-path contract: commands that fail now log the full traceback to the provider log and exit 1 with the error message on stdout, per the HF script contract documented in the wrapper-script headers. `hf-gke` previously printed `ERROR: Command returned empty result` to stdout with exit 0, which HostFactory would try to parse as a success response. It now exits 1.



**Scope**
GCE and GKE providers, hf-monitor.



**Verified at three levels:**
Unit and contract tests (new):
- `tests/unit/common/test_log_bootstrap.py`: warnings are routed to the log and never to stdout/stderr; log path matches the wrapper scripts' fallback chain; bootstrap is idempotent, reinstalls after external handler removal, and degrades to a `NullHandler` when nothing is writable; provider JSON settings are re-applied.
- `tests/unit/{gce,gke}_provider/test_stdout_contract.py`: run the real CLIs in a subprocess with `PYTHONWARNINGS=always` and assert stdout parses as JSON with nothing else, stderr is empty, failures exit 1 with the error message on stdout, and the traceback lands in the provider log.


Script-level:
- Built the provider binaries from source against `google-auth==2.47.0` (matching `hf-gcpgce-provider-1.0.0-110.el10.x86_64`).
- Invoked the binaries directly and via the wrapper scripts: stdout contains only the JSON response; the `FutureWarning` appears in the provider log instead of stderr.


End-to-end with the Cluster Management Console:
- Restarted HostFactory: `egosh service stop HostFactory` / `egosh service start HostFactory`.
- Confirmed templates list correctly, scheduled a machine request, and returned the machines through the console.
- Confirmed warnings from these invocations are appended to the provider log and no longer reach stdout/stderr.


**Affected Files**
Source:
- hf-provider/src/common/log_bootstrap.py (new)
- hf-provider/src/gce_provider/\_\_main\_\_.py
- hf-provider/src/gce_provider/config.py
- hf-provider/src/gce_provider/pubsub.py
- hf-provider/src/gke_provider/\_\_main\_\_.py
- hf-provider/src/gke_provider/config.py

Tests (new):
- hf-provider/tests/unit/conftest.py
- hf-provider/tests/unit/common/test_log_bootstrap.py
- hf-provider/tests/unit/gce_provider/test_stdout_contract.py
- hf-provider/tests/unit/gke_provider/test_stdout_contract.py


**Checklist**
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR

Fixes: #86