### PR TITLE
fix: Resolve malformed JSON, standardize uv sync, and bump hf-provider to 0.3.7

### DIFF
--- a/.github/workflows/build_rpm.yaml
+++ b/.github/workflows/build_rpm.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         version: ["8", "9", "10"]
@@ -48,15 +48,20 @@ jobs:
 
     - name: Add a directory to the PATH
       run: echo "/usr/bin" >> $GITHUB_PATH
+    
+    - name: Install uv version 0.11.26
+      env:
+        UV_VERSION: 0.11.26
+        UV_INSTALL_DIR: ${{runner.temp}}/uv
+      run: |
+           curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | env UV_INSTALL_DIR="${UV_INSTALL_DIR}" sh
+           echo "${UV_INSTALL_DIR}" >> "$GITHUB_PATH"
+           "${UV_INSTALL_DIR}/uv" --version
 
-    - name: install uv, venv, dependencies and pyinstaller
+    - name: Uv Sync and Install Pyinstaller
       run: |
            cd hf-provider
-           curl -LsSf https://astral.sh/uv/install.sh | sh
-           source $HOME/.local/bin/env
-           uv venv
-           source .venv/bin/activate
-           uv pip install -r pyproject.toml
+           uv sync --locked
            uv pip install pyinstaller
 
     - name: run common unit tests
@@ -64,32 +69,28 @@ jobs:
            HF_PROVIDER_CONFDIR: ${{ github.workspace }}/hf-provider/tests/resources/provider-config/config-001/conf/providers/gcpgkeinst
       run: |
            cd hf-provider
-           source .venv/bin/activate
-           python -m pytest tests/unit/common
+           uv run --locked python -m pytest tests/unit/common
 
     - name: run gcpgce unit tests
       env: 
            HF_PROVIDER_CONFDIR: ${{ github.workspace }}/hf-provider/tests/resources/provider-config/config-001/conf/providers/gcpgceinst
       run: |
            cd hf-provider
-           source .venv/bin/activate
-           python -m pytest tests/unit/gce_provider
+           uv run --locked python -m pytest tests/unit/gce_provider
 
     - name: run gcpgke unit tests
       env: 
            HF_PROVIDER_CONFDIR: ${{ github.workspace }}/hf-provider/tests/resources/provider-config/config-001/conf/providers/gcpgkeinst
       run: |
            cd hf-provider
-           source .venv/bin/activate
-           python -m pytest tests/unit/gke_provider
+           uv run --locked python -m pytest tests/unit/gke_provider
 
     - name: build clis
       run: |
            cd hf-provider
-           source .venv/bin/activate
-           uv run pyinstaller hf-gce.spec --clean
-           uv run pyinstaller hf-monitor.spec --clean
-           uv run pyinstaller hf-gke.spec --clean
+           uv run --locked pyinstaller hf-gce.spec --clean
+           uv run --locked pyinstaller hf-monitor.spec --clean
+           uv run --locked pyinstaller hf-gke.spec --clean
 
     - name: run gce rpmbuild
       id: gce-rpm

--- a/hf-provider/CHANGELOG.md
+++ b/hf-provider/CHANGELOG.md
@@ -1,0 +1,168 @@
+# Changelog
+
+All hf-provider notable changes to this project will be documented in this file.
+
+## [0.3.7] - 2026-07-16
+
+Relevant PRs:
+- #92 - Redirect provider-script stderr to prevent HostFactory JSON parsing failures
+- #97 - Fixed GCE service-account credentials path handling
+- #98 - Route python warnings/future-warnings through provider logging
+- #99 - Integrate provider fixes, standardize locked `uv` workflows
+
+#### Added
+- Added `src/common/log_bootstrap.py` to initialize shared logging for `hf-gce`, `hf-gke`, and `hf-monitor`.
+- Added automatic capture of Python warnings and routing them to the provider log instead of `stderr`.
+- Added fallback logging to the system temporary directory when the configured provider log directory is unavailable.
+- Added some new test cases related to logging.
+
+#### Fixed
+- Fixed malformed HostFactory responses caused by warnings or diagnostic messages being mixed with JSON output.
+- Redirected `stderr` from all GCE and GKE wrapper scripts to the provider log, keeping `stdout` reserved for command responses only.
+- Fixed duplicate log records and concurrent rotation causes by multiple handlers writing to the same log file.
+- Prevented logging from creating a file named `None` when `HF_PROVIDER_LOGDIR` is unset.
+- Prevented logging fallbacks from writing to `stderr` when no log directory is writable.
+- Fixed failed commands returning exit code `0`; provider failures now return exit code `1`, output the error message through `stdout`, and record the trackback in the provider log.
+- Fixed `hf-gke` treating an empty command result as successful response.
+- Fixed GCE service-account authentication failing with `'str' object has no attribute 'stat'` when `GCP_CREDENTIALS_FILE` is configured.
+- Fixed relative GCE credential paths by resolving them against the provider configuration directory.
+- Allowed missing or invalid service-account files to fall back to the `Application Default Credentials` instead of terminating the provider.
+
+#### Changed
+- Initialized provider logging before importing third-party libraries import-time warnings are captured.
+- Centralized GCE an GKE logging configuration through the shared logging bootstrap.
+- Updated provider configuration loading to reapply the configured log path, level, maximum file size and rotation count.
+- Standardized the `stdout` contract so successful responses contain clean JSON and failed responses follow the HostFactory error-response behavior.
+
+### Build and Release Infrastructure
+
+#### Added
+- Added the required `uv` version to `pyproject.toml`.
+
+#### Changed
+- Pinned the GitHub Actions runner to `ubuntu-24.04`.
+- Pinned `uv` to version `0.11.26`.
+- Changed dependency installation to `uv sync --locked`.
+- Change unit-test and Pyinstaller execution to use `uv run --locked`.
+- Regenerated uv.lock to synchronize the resolved dependency versions used by source and RPM builds.  
+
+## [0.3.6] - 2026-01-22
+
+Relevant PRs:
+- #52 - RPM build `PATH` fix
+- #54 - Tag-based RPM versions
+- #55 - Shell quoting fix
+- #56 - Provider unit-test fixes
+- #61 - RPM build improvements, hf-monitor packaging, and unit-test integration
+- #62 - GCE and GKE provider installation-validation scripts
+
+#### Added
+- Added the validation scripts to the GCE and GKE RPM package specifications as executable files.
+
+#### Fixed
+- Fixed failing unit tests for both GCE and GKE providers.
+- Cleared cached GKE configuration state between tests to prevent `lru_cache` data from leakiing across test cases.
+- Removed a non-atomic `call_count` assertion from the GCE instance-fetching test.
+- Prevented intermittent GitHub Actions failures where the returned instance count was correct but the mock call count had not been updated consistently.
+
+#### Changed
+- Updated GCE mocks to configure methods on the factory-created client instance.
+- Updated assertions to match the actual client-contrustion and invocation flow.
+
+### Build and Release Infrastructure
+
+#### Added
+- Added `usr/bin` to `GITHUB_PATH` before building the provider command-line applications.
+- Added automatic RPM version detection from Git tags.
+- Added the missing `hf-monitor` executable to the RPM build workflow
+
+#### Fixed
+- Fixed RPM workflows failures caused by required executables not being found in the build environment.
+- Fixed malformed shell quoting in the tag-version extraction command introduced by PR #54. Corrected the expression that removes the leading `v` from `github.ref_name`.
+- Prevented shell parsing failures while setting the `VERSION` environment variable.
+
+#### Changed
+- Tags matching the following pattern are converted into RPM versions `v0.3.6` -> `0.3.6`
+- Updated the GCE RPM package description to state the `hf-monitor` is used to track and monitor GCE VM events.
+- Non-semantic-version tags fall back to RPM version `1.0.0`.
+- Updated generated artifact names to use the calculated version instead of a hardcoded `1.0.0`.
+- Refactored dependency, virtual-environment, and Pyinstaller setup into a clearer build-pipeline stage.
+- Replace the older direct Pyinstaller commmands with the maintained specification-file-based commands: `uv run pyinstaller hf-gce.spec --clean...`
+
+## [0.3.5] - 2025-12-17
+
+Relevant PRs:
+- #46 - RHEL 10 RPM build support.
+- #44 - Centralized provider installation
+- #42 - Expired-machine database cleanup
+
+#### Added
+- Added a machine db `trim` operation that permanently deletes expired returned-machine records.
+- Added the `trimDB` CLI command.
+- The cleanup command can be executed manually, through an external scheduler or automatically, depending on configuration.
+- Added `AUTO_RUN_TRIM_DB_CMD` to control automatic cleanup behavior and `RETURNED_VM_TTL` to define how many days returned VM records are retained.
+- Added database-name configuration support.
+
+#### Fixed
+- Reduced the risk of initialization being executed multiple times concurrently. 
+- Prevented repeated database-cleanup execution.
+- Corrected and narrowed expired-machine deletion criteria.
+
+#### Changed
+- Moved process-level GCE initialization into a dedicated `initialize.py` module.
+- Added `_init_all()` as the central initialization method. Protected initialization with a thread lock.
+- Preserved initialization within `cmd_get_available_templates()` because it is considered the safest location for that command. Initialization exceptions are logged and propagated instead of being silently ignored.
+- Removed the automatic trim trigger from the group-delete handler. Narrowed the cleanup query to avoid deleting records outside the intended returned-machine retention criteria.
+
+### Build and Release Infrastructure
+
+#### Added
+- Added RHEL/Rocky Linux 10 to the RPM build matrix.
+- Retained support for RHEL/Rocky Linux 8 and 9.
+- Added OS-specific Python package selection:
+    - `python39` for versions 8 and 9.
+    - `python3` for version 10.
+- Added Node.js installation to the build environment.
+
+#### Fixed
+- Improved RPM build compatibility with RHEL/Rocky Linux 10.
+
+#### Changed
+- Replaced `pip3 install uv` with official `uv` installation script.
+
+## [0.3.4] - 2025-10-17
+
+#### Added
+- Added rotating file-log support for both GCE and GKE providers.
+- Added the `LOG_MAX_FILE_SIZE = 10 MB` and `LOG_MAX_ROTATE = 5` configuration options.
+
+#### Fixed
+- Prevented provider log files for growing indefinitely by introducing maximum-size and backup-count controls.
+
+#### Changed
+- Introduced RotatingFileHandler for controlling log-file growth.
+- Applied the same rotating-file behavior to both `gce_provider/config.py` and `gke_provider/config.py`
+
+
+## [0.3.3] - 2025-10-17
+
+#### Added
+- Standalone `hf-monitor` executable for running GCE provider event-monitoring process.
+- Added a corresponding `hf-monitor.spec` pyinstaller build specification.
+- Added the `hf-monitor` entry point to `pyproject.toml`.
+- Added the `--monitor` option to `hf-gce`.
+
+#### Fixed
+- Fixed incorrect `getRequestStatus` response and JSON structure.
+- Fixed machines being reported as running while still pending; centralized database retry behavior.
+
+#### Changed
+- Updated the provider build process to use pyinstaller with `--clean`.
+- Updated GCE installation and monitoring documentation.
+- Updated build instructions to generate and install both `hf-gce` and `hf-monitor`.
+- Allowed the GCE provider to launch its monitoring daemon through: `hf-gce <command> --monitor`
+
+#### Deprecated
+- The legacy `gcphf` command remained available for backward compatibility.
+- The project configuration explicitly marked `gcphf` as slated for future removal.
+- Users should migrate the provider-specific commands: `hf-gce`, `hf-gke`, and `hf-monitor`.

--- a/hf-provider/README.md
+++ b/hf-provider/README.md
@@ -40,27 +40,38 @@ This guide covers setting up the development environment, running tests, and bui
 ## Prerequisites
 
 *   **Python 3.9+**
-*   **uv**: A Python package installer and resolver. [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
+*   **uv v0.11.26**: A Python package installer and resolver. [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ## Install Dependencies
 
-1.  **Navigate to the project directory:**
+1. **Install uv**
+    ```bash
+    export UV_VERSION=0.11.26
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
+    ```
+
+1.  **Verify uv version 0.11.26:**
+
+    ```bash
+    uv --version
+    # Output: uv 0.11.26
+    ```
+
+2.  **Navigate to the project directory:**
 
     ```bash
     cd hf-provider
     ```
 
-2.  **Create and activate a virtual environment:**
+3.  **Run uv sync:**
 
     ```bash
-    uv venv
-    source .venv/bin/activate
+    uv sync --locked
     ```
 
-3.  **Install dependencies and PyInstaller:**
+4.  **Install PyInstaller:**
 
     ```bash
-    uv pip install .
     uv pip install pyinstaller
     ```
 
@@ -71,15 +82,15 @@ Run unit tests to ensure the setup is correct. These commands simulate the GitHu
 ```bash
 # Run Common Tests
 export HF_PROVIDER_CONFDIR=./tests/resources/provider-config/config-001/conf/providers/gcpgkeinst
-python -m pytest tests/unit/common
+uv run python -m pytest tests/unit/common
 
 # Run GCP GCE Provider Tests
 export HF_PROVIDER_CONFDIR=./tests/resources/provider-config/config-001/conf/providers/gcpgceinst
-python -m pytest tests/unit/gce_provider
+uv run python -m pytest tests/unit/gce_provider
 
 # Run GCP GKE Provider Tests
 export HF_PROVIDER_CONFDIR=./tests/resources/provider-config/config-001/conf/providers/gcpgkeinst
-python -m pytest tests/unit/gke_provider
+uv run python -m pytest tests/unit/gke_provider
 ```
 
 ## Build CLIs
@@ -88,13 +99,13 @@ Build the standalone CLI executables for GCE and GKE providers.
 
 ```bash
 # Build hf-gce CLI (GCE clusters)
-uv run pyinstaller hf-gce.spec --clean
+uv run --locked pyinstaller hf-gce.spec --clean
 
 # Build hf-monitor CLI (GCE VM monitoring)
-uv run pyinstaller hf-monitor.spec --clean
+uv run --locked pyinstaller hf-monitor.spec --clean
 
 # Build hf-gke CLI (GKE clusters)
-uv run pyinstaller hf-gke.spec --clean
+uv run --locked pyinstaller hf-gke.spec --clean
 ```
 
 **Verify the build:**
@@ -144,30 +155,28 @@ The executables are created in the `dist/` directory.
 
 2. Set the working directory to the root of this module.
 
-3. Activate a virtual environment, e.g.: `uv venv; source .venv/bin/activate`
+3. Install the project dependencies with `uv sync --locked`
 
-4. Install the project dependencies with `uv pip install -r pyproject.toml`
-
-5. Execute the CLI using:
+4. Execute the CLI using:
    ```bash
    # GCE provider
-   uv run hf-gce --help
+   uv run --locked hf-gce --help
    
    # GKE provider
-   uv run hf-gke --help
+   uv run --locked hf-gke --help
    ```
    This should give you a list of available commands.
 
-6. For the following commands: `requestMachines`, `requestReturnMachines`, `getRequestStatus`, and `getReturnRequests`, you should include a JSON payload either as a string argument, or using `--json-file [payload file]`. Examples:
+5. For the following commands: `requestMachines`, `requestReturnMachines`, `getRequestStatus`, and `getReturnRequests`, you should include a JSON payload either as a string argument, or using `--json-file [payload file]`. Examples:
        
    ```bash
-   uv run hf-gke getRequestStatus '{"machines": {"name": "foo"}}'
+   uv run --locked hf-gke getRequestStatus '{"machines": {"name": "foo"}}'
    ```
 
      or
 
      ```bash
-     uv run hf-gke requestMachines --json-file ./test/resources/request-machines/request-machines-001.json
+     uv run --locked hf-gke requestMachines --json-file ./test/resources/request-machines/request-machines-001.json
      ```
 
      The `--json-file` can be an absolute or relative path.

--- a/hf-provider/pyproject.toml
+++ b/hf-provider/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "google-symphony-hf"
 version = "0.3.7"
-description = "Default template"
+description = "IBM Spectrum Symphony Connectors for Google Cloud let you add compute resources from Google Cloud to your Symphony clusters. When your high performance computing (HPC) workloads need more capacity than your existing infrastructure provides, the connectors let Symphony's host factory service automatically provision Compute Engine virtual machines (VM) instances or pods in Google Kubernetes Engine (GKE). This approach lets you scale your Symphony environment into Google Cloud to meet peak demand for your HPC workloads."
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = "==3.9.*"
@@ -55,7 +55,7 @@ gcphf  = "gke_provider.__main__:main"
 
 # (Optional but nice)
 [project.urls]
-Homepage = "https://example.com/"
+Homepage = "https://docs.cloud.google.com/compute/docs/instances/ibm-symphony/overview"
 Repository = "https://github.com/google/symphony-gcp"
 
 # ------------------------------

--- a/hf-provider/pyproject.toml
+++ b/hf-provider/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # ------------------------------
 [project]
 name = "google-symphony-hf"
-version = "0.3.6"
+version = "0.3.7"
 description = "Default template"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -56,7 +56,7 @@ gcphf  = "gke_provider.__main__:main"
 # (Optional but nice)
 [project.urls]
 Homepage = "https://example.com/"
-Repository = "https://example.com/repo"
+Repository = "https://github.com/google/symphony-gcp"
 
 # ------------------------------
 # Setuptools: src/ discovery & data files
@@ -86,3 +86,6 @@ max-line-length = 100
 
 [tool.isort]
 profile = "black"
+
+[tool.uv]
+required-version="==0.11.26"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getAvailableTemplates.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getAvailableTemplates.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce getAvailableTemplates -f $inJson
+$homeDir/bin/hf-gce getAvailableTemplates -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getRequestStatus.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getRequestStatus.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce getRequestStatus -f $inJson
+$homeDir/bin/hf-gce getRequestStatus -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getReturnRequests.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/getReturnRequests.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce getReturnRequests -f $inJson
+$homeDir/bin/hf-gce getReturnRequests -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestMachines.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce requestMachines -f $inJson
+$homeDir/bin/hf-gce requestMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestReturnMachines.sh
+++ b/hf-provider/resources/gce_cli/1.2/providerplugins/gcpgce/scripts/requestReturnMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gce requestReturnMachines -f $inJson
+$homeDir/bin/hf-gce requestReturnMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getAvailableTemplates.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getAvailableTemplates.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke getAvailableTemplates -f $inJson
+$homeDir/bin/hf-gke getAvailableTemplates -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getRequestStatus.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getRequestStatus.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke getRequestStatus -f $inJson
+$homeDir/bin/hf-gke getRequestStatus -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getReturnRequests.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/getReturnRequests.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke getReturnRequests -f $inJson
+$homeDir/bin/hf-gke getReturnRequests -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestMachines.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke requestMachines -f $inJson
+$homeDir/bin/hf-gke requestMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestReturnMachines.sh
+++ b/hf-provider/resources/gke_cli/1.2/providerplugins/gcpgke/scripts/requestReturnMachines.sh
@@ -10,4 +10,4 @@ inJson=$2
 scriptDir=`dirname $0`
 homeDir="$(cd "$scriptDir" && cd .. && pwd)"
 
-$homeDir/bin/hf-gke requestReturnMachines -f $inJson
+$homeDir/bin/hf-gke requestReturnMachines -f $inJson 2>>"${HF_PROVIDER_LOGDIR:-/tmp}/${HF_PROVIDER_NAME:-gcp-symphony}-provider.${EGOSC_INSTANCE_HOST:-$(hostname)}.log"

--- a/hf-provider/src/common/log_bootstrap.py
+++ b/hf-provider/src/common/log_bootstrap.py
@@ -1,0 +1,183 @@
+import logging
+import logging.handlers
+import os
+import socket
+import tempfile
+from typing import Iterator, Optional
+
+
+ENV_HF_PROVIDER_NAME = "HF_PROVIDER_NAME"
+ENV_HF_PROVIDER_LOGDIR = "HF_PROVIDER_LOGDIR"
+ENV_EGOSC_INSTANCE_HOST = "EGOSC_INSTANCE_HOST"
+ENV_BOOTSTRAP_LOG_LEVEL = "GCP_HF_LOG_LEVEL"
+
+DEFAULT_HF_PROVIDER_NAME = "gcp-symphony"
+DEFAULT_LOG_LEVEL = "WARNING"
+DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+DEFAULT_LOG_BACKUP_COUNT = 5
+
+LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+
+# https://docs.python.org/3.9/library/logging.html#logging-levels
+_LEVEL_NAMES = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
+
+
+class _ProviderLogHandler(logging.handlers.RotatingFileHandler):
+    """Marker type for the handler this module manages on the root logger."""
+
+
+class _ProviderNullHandler(logging.NullHandler):
+    """Marker for the degraded mode where no log location is writable."""
+
+
+def _installed_handler() -> Optional[logging.Handler]:
+    """Return the handler installed on the root logger, if any."""
+    return next(
+        (
+            handler
+            for handler in logging.getLogger().handlers
+            if isinstance(handler, (_ProviderLogHandler, _ProviderNullHandler))
+        ),
+        None,
+    )
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname()
+    except Exception:
+        return "localhost"
+
+
+def _log_filename() -> str:
+    hf_provider_name = os.environ.get(ENV_HF_PROVIDER_NAME) or DEFAULT_HF_PROVIDER_NAME
+    hostname = os.environ.get(ENV_EGOSC_INSTANCE_HOST) or _hostname()
+    return f"{hf_provider_name}-provider.{hostname}.log"
+
+
+def _candidate_log_files() -> Iterator[str]:
+    filename = _log_filename()
+    log_dir = os.environ.get(ENV_HF_PROVIDER_LOGDIR)
+    if log_dir:
+        yield os.path.join(log_dir, filename)
+    yield os.path.join(tempfile.gettempdir(), filename)
+
+
+def default_log_file() -> str:
+    return next(_candidate_log_files())
+
+
+def _resolve_level(level: Optional[str]) -> int:
+    return _LEVEL_NAMES.get((level or DEFAULT_LOG_LEVEL).upper(), logging.WARNING)
+
+
+def _create_file_handler(
+        logfile: str, max_bytes: int, backup_count: int
+)-> Optional["_ProviderLogHandler"]:
+    try:
+        handler = _ProviderLogHandler(
+            filename=logfile, maxBytes=max_bytes, backupCount=backup_count
+        )
+        handler.setFormatter(logging.Formatter(LOG_FORMAT))
+        return handler
+    except (OSError, ValueError):
+        return None
+
+
+def _install_handler(handler: logging.Handler) -> None:
+    root_logger = logging.getLogger()
+    for existing_handler in list(root_logger.handlers):
+        if isinstance(existing_handler, (_ProviderLogHandler, _ProviderNullHandler)):
+            root_logger.removeHandler(existing_handler)
+            try:
+                existing_handler.close()
+            except Exception:
+                pass
+    root_logger.addHandler(handler)
+
+
+def bootstrap_logging() -> None:
+    """ Initialize logging for the provider. 
+    Must be called first before any third-party import.
+    """
+    if _installed_handler() is not None:
+        return
+    
+    logging.raiseExceptions = False
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(_resolve_level(os.environ.get(ENV_BOOTSTRAP_LOG_LEVEL)))
+
+    handler : Optional[logging.Handler] = None
+    for candidate_logfile in _candidate_log_files():
+        handler = _create_file_handler(
+            logfile=candidate_logfile,
+            max_bytes=DEFAULT_LOG_MAX_BYTES,
+            backup_count=DEFAULT_LOG_BACKUP_COUNT,
+        )
+        if handler is not None:
+            break
+    if handler is None:
+        handler = _ProviderNullHandler()
+
+    _install_handler(handler)
+    logging.captureWarnings(True)
+
+
+def configure_logging(
+    logfile: Optional[str] = None,
+    level: Optional[str] = None,
+    max_bytes: Optional[int] = None,
+    backup_count: Optional[int] = None
+) -> None:
+    """Re-apply log file, level, and rotation settings from the provider JSON configuration.
+
+    Args:
+        logfile: Path to the log file.
+        level: Logging level.
+        max_bytes: Maximum size of each log file.
+        backup_count: Number of backup log files to keep.
+    """
+    if _installed_handler() is None:
+        bootstrap_logging()
+
+    if level is not None:
+        logging.getLogger().setLevel(_resolve_level(level))
+    
+    if logfile is None:
+        return
+
+    target_max_bytes = DEFAULT_LOG_MAX_BYTES if max_bytes is None else max_bytes
+    target_backup_count = DEFAULT_LOG_BACKUP_COUNT if backup_count is None else backup_count
+
+    current_handler = _installed_handler()
+    # old one closed first
+    if (
+        
+        isinstance(current_handler, _ProviderLogHandler)
+        and os.path.abspath(current_handler.baseFilename) == os.path.abspath(logfile)
+        and current_handler.maxBytes == target_max_bytes
+        and current_handler.backupCount == target_backup_count
+    ):
+        return
+    
+    new_handler = _create_file_handler(
+        logfile=logfile,
+        max_bytes=target_max_bytes,
+        backup_count=target_backup_count,
+    )
+
+    if new_handler is None:
+        logging.getLogger(__name__).warning(
+            "Could not open configured log file %r, keeping the current log target",
+            logfile,
+        )
+        return
+    _install_handler(new_handler)

--- a/hf-provider/src/gce_provider/__main__.py
+++ b/hf-provider/src/gce_provider/__main__.py
@@ -1,9 +1,13 @@
 import argparse
 import json
+import logging
 import os
 import sys
 from argparse import Namespace
 from typing import Any, Callable, Optional
+
+from common.log_bootstrap import bootstrap_logging
+bootstrap_logging()
 
 from pydantic import BaseModel
 
@@ -32,6 +36,7 @@ from gce_provider.model.models import HFGceRequestMachines
 from gce_provider.pubsub import launch_pubsub_daemon, main as monitor_events
 from gce_provider.utils.constants import CommandNames
 
+logger = logging.getLogger(__name__)
 
 #   1. Before running this module,
 #      set up ADC as described in https://cloud.google.com/docs/authentication/external/set-up-adc
@@ -320,6 +325,7 @@ def main():
 
         sys.exit(0)
     except Exception as e:
+        logger.exception(f"Command failed: {e}")
         print(f"Error: {e}")
         sys.exit(1)
 

--- a/hf-provider/src/gce_provider/config.py
+++ b/hf-provider/src/gce_provider/config.py
@@ -1,14 +1,13 @@
 import logging
 import os
-import sys
 from functools import lru_cache
 
 from dotenv import load_dotenv
 from socket import gethostname
 
 import common.utils.path_utils as path_utils
+from common import log_bootstrap
 from common.utils.file_utils import load_json_file
-from logging.handlers import RotatingFileHandler
 
 # Load environment variables from .env file (if it exists)
 load_dotenv()
@@ -17,10 +16,8 @@ load_dotenv()
 ENV_VAR_PREFIX = "GCP_HF_"
 
 # Environment vars set by HostFactory
-ENV_EGOSC_INSTANCE_HOST = "EGOSC_INSTANCE_HOST"
 ENV_HF_DBDIR = "HF_DBDIR"
 ENV_HF_PROVIDER_CONFDIR = "HF_PROVIDER_CONFDIR"
-ENV_HF_PROVIDER_LOGDIR = "HF_PROVIDER_LOGDIR"
 ENV_HF_PROVIDER_NAME = "HF_PROVIDER_NAME"
 
 
@@ -70,20 +67,6 @@ ENV_PLUGIN_DB_FILENAME = prepend_env_var("DB_FILENAME")
 ENV_PLUGIN_CONFIG_FILENAME = prepend_env_var("CONFIG_FILENAME")
 
 HF_PROVIDER_NAME = os.environ.get(ENV_HF_PROVIDER_NAME, DEFAULT_HF_PROVIDER_NAME)
-HF_PROVIDER_LOGDIR = os.environ.get(
-    ENV_HF_PROVIDER_LOGDIR,
-    os.path.dirname(sys.argv[0]),  # default to directory of the binary
-)
-EGOSC_INSTANCE_HOST = os.environ.get(ENV_EGOSC_INSTANCE_HOST)
-HF_PROVIDER_LOGFILE = (
-    os.path.join(
-        HF_PROVIDER_LOGDIR, f"{HF_PROVIDER_NAME}-provider.{EGOSC_INSTANCE_HOST}.log"
-    )
-    if HF_PROVIDER_LOGDIR
-    else None
-)
-
-logging.getLogger(__name__)
 
 
 class Config:
@@ -122,15 +105,20 @@ class Config:
             )
 
         # configure logging. This should occur before any log entries are emitted
-        self.hf_provider_log_file = hf_provider_conf.get(
-            CONFIG_VAR_LOGFILE, HF_PROVIDER_LOGFILE
+        self.hf_provider_log_file = (
+            hf_provider_conf.get(CONFIG_VAR_LOGFILE) or log_bootstrap.default_log_file()
         )
         self.log_level = hf_provider_conf.get(CONFIG_VAR_LOG_LEVEL, DEFAULT_LOG_LEVEL)
-
-        logging.basicConfig(
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            filename=self.hf_provider_log_file,
-            level=self.log_level.upper() if self.log_level else DEFAULT_LOG_LEVEL,
+        
+        log_bootstrap.configure_logging(
+            logfile=str(self.hf_provider_log_file),
+            level=self.log_level,
+            max_bytes=int(
+                hf_provider_conf.get(CONFIG_VAR_LOG_MAX_FILE_SIZE, DEFAULT_LOG_MAX_FILE_SIZE)
+            ) * 1024 * 1024,  # nth MB in bytes
+            backup_count=int(
+                hf_provider_conf.get(CONFIG_VAR_LOG_MAX_ROTATE, DEFAULT_LOG_MAX_ROTATE)
+            )
         )
         self.logger = logging.getLogger(__name__)
 
@@ -214,35 +202,6 @@ class Config:
                 CONFIG_VAR_PUBSUB_AUTOLAUNCH, DEFAULT_PUBSUB_AUTOLAUNCH
             )
         )
-
-        # configure logging
-        self.hf_provider_log_file = hf_provider_conf.get(
-            CONFIG_VAR_LOGFILE, HF_PROVIDER_LOGFILE
-        )
-        self.log_level = hf_provider_conf.get(CONFIG_VAR_LOG_LEVEL, DEFAULT_LOG_LEVEL)
-
-        # Create rotating handler (append by default)
-        handler = RotatingFileHandler(
-            filename=str(self.hf_provider_log_file),
-            maxBytes=int(
-                hf_provider_conf.get(CONFIG_VAR_LOG_MAX_FILE_SIZE, DEFAULT_LOG_MAX_FILE_SIZE)
-            ) * 1024 * 1024,  # nth MB in bytes
-            backupCount=hf_provider_conf.get(
-                CONFIG_VAR_LOG_MAX_ROTATE, DEFAULT_LOG_MAX_ROTATE
-            )
-        )
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s",
-        )
-        handler.setFormatter(formatter)
-
-        logging.basicConfig(
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            filename=self.hf_provider_log_file,
-            level=self.log_level.upper() if self.log_level else DEFAULT_LOG_LEVEL,
-        )
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(handler)
 
         # iterate over the class attributes and log them
         if self.log_level.upper() == "DEBUG":

--- a/hf-provider/src/gce_provider/pubsub.py
+++ b/hf-provider/src/gce_provider/pubsub.py
@@ -5,6 +5,9 @@ import sys
 from concurrent.futures import TimeoutError
 from pprint import pprint
 
+from common.log_bootstrap import bootstrap_logging
+bootstrap_logging()
+
 import google.cloud.pubsub_v1 as pubsub
 
 from gce_provider.config import get_config

--- a/hf-provider/src/gce_provider/utils/client_factory.py
+++ b/hf-provider/src/gce_provider/utils/client_factory.py
@@ -19,20 +19,21 @@ def get_credentials(
     if config is None:
         config = get_config()
 
-    if config.gcp_credentials_file and Path.exists(config.gcp_credentials_file):
+    if config.gcp_credentials_file:
         credentials_file_path = normalize_path(
             config.hf_provider_conf_dir, config.gcp_credentials_file
         )
 
-        try:
-            credentials_json = load_json_file(credentials_file_path)
-            return service_account.Credentials.from_service_account_info(
-                credentials_json
-            )
-        except Exception:
-            config.logger.error(
-                f"Unable to create service account credentials from file {credentials_file_path}"
-            )
+        if Path(credentials_file_path).exists():
+            try:
+                credentials_json = load_json_file(credentials_file_path)
+                return service_account.Credentials.from_service_account_info(
+                    credentials_json
+                )
+            except Exception as e:
+                config.logger.exception(
+                    f"Unable to create service account credentials from file {credentials_file_path}: {e}"
+                )
 
     logging.warning(
         "No credentials file defined, or file does not exist. Will rely on application default credentials."

--- a/hf-provider/src/gke_provider/__main__.py
+++ b/hf-provider/src/gke_provider/__main__.py
@@ -1,8 +1,12 @@
 import argparse
 import json
+import logging
 import os
 import sys
 from typing import Any, Dict, Optional
+
+from common.log_bootstrap import bootstrap_logging
+bootstrap_logging()
 
 from typing_extensions import Self
 
@@ -19,6 +23,8 @@ from gke_provider.commands.get_return_requests import get_return_requests
 from gke_provider.commands.request_machines import request_machines
 from gke_provider.commands.request_return_machines import request_return_machines
 from gke_provider.config import get_config
+
+logger = logging.getLogger(__name__)
 
 # Initialize configuration
 config = get_config()
@@ -231,9 +237,8 @@ def dispatch_command(command: str, payload: Optional[dict]):
             print(output)
             return
         else:
-            config.logger.info(f"DISPATCHING|command: {command}; ERROR: empty result")
-            print("ERROR: Command returned empty result")
-            return
+            config.logger.error(f"DISPATCHING|command: {command}; ERROR: empty result")
+            raise RuntimeError(f"Command {command} returned no result")
     else:
         raise Exception(f"Invalid command: {cmd}")
 
@@ -283,6 +288,7 @@ def main() -> int:
         dispatch_command(command, payload)
         sys.exit(0)
     except Exception as e:
+        logger.exception(f"Command failed: {e}")
         print(f"Error: {e}")
         sys.exit(1)
 

--- a/hf-provider/src/gke_provider/config.py
+++ b/hf-provider/src/gke_provider/config.py
@@ -6,8 +6,8 @@ from socket import gethostname
 from dotenv import load_dotenv
 
 import common.utils.path_utils as path_utils
+from common import log_bootstrap
 from common.utils.file_utils import load_json_file
-from logging.handlers import RotatingFileHandler
 
 # Load environment variables from .env file (if it exists)
 load_dotenv()
@@ -37,15 +37,6 @@ DEFAULT_HF_PROVIDER_NAME = "gcp-symphony"
 
 HF_PROVIDER_NAME = os.environ.get("HF_PROVIDER_NAME", DEFAULT_HF_PROVIDER_NAME)
 HF_PROVIDER_CONFDIR_ENV = "HF_PROVIDER_CONFDIR"
-HF_PROVIDER_LOGDIR = os.environ.get("HF_PROVIDER_LOGDIR")
-EGOSC_INSTANCE_HOST = os.environ.get("EGOSC_INSTANCE_HOST")
-HF_PROVIDER_LOGFILE = (
-    os.path.join(HF_PROVIDER_LOGDIR, f"{HF_PROVIDER_NAME}-provider.{EGOSC_INSTANCE_HOST}.log")
-    if HF_PROVIDER_LOGDIR
-    else None
-)
-
-logging.getLogger(__name__)
 
 PROVIDER_CONF_GKE_KUBECONFIG = "GKE_KUBECONFIG"
 KUBECONFIG_DEFAULT_ENV = "KUBECONFIG"
@@ -56,6 +47,8 @@ class Config:
 
     def __init__(self) -> None:
         """Load configuration values from environment"""
+        self.logger = logging.getLogger(__name__)
+
         self.hf_provider_name = HF_PROVIDER_NAME
 
         self.hf_provider_conf_dir: str = os.environ.get(HF_PROVIDER_CONFDIR_ENV, "")
@@ -135,31 +128,21 @@ class Config:
             hf_provider_conf.get("GKE_POLLING_INTERVAL", DEFAULT_POLLING_INTERVAL)
         )
         # This allows the user to override the default HF log directory/filename
-        self.hf_provider_log_file = hf_provider_conf.get("LOGFILE", HF_PROVIDER_LOGFILE)
+        self.hf_provider_log_file = (
+            hf_provider_conf.get("LOGFILE") or log_bootstrap.default_log_file()
+        )
         self.log_level = hf_provider_conf.get("LOG_LEVEL", DEFAULT_LOG_LEVEL)
 
-        # Create rotating handler (append by default)
-        handler = RotatingFileHandler(
-            filename=str(self.hf_provider_log_file),
-            maxBytes=int(
+        log_bootstrap.configure_logging(
+            logfile=str(self.hf_provider_log_file),
+            level=self.log_level,
+            max_bytes=int(
                 hf_provider_conf.get("LOG_MAX_FILE_SIZE", DEFAULT_LOG_MAX_FILE_SIZE)
             ) * 1024 * 1024,  # nth MB in bytes
-            backupCount=hf_provider_conf.get(
-                "LOG_MAX_ROTATE", DEFAULT_LOG_MAX_ROTATE
+            backup_count=int(
+                hf_provider_conf.get("LOG_MAX_ROTATE", DEFAULT_LOG_MAX_ROTATE)
             )
         )
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s",
-        )
-        handler.setFormatter(formatter)
-
-        logging.basicConfig(
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            filename=self.hf_provider_log_file,
-            level=self.log_level.upper() if self.log_level else DEFAULT_LOG_LEVEL,
-        )
-        self.logger = logging.getLogger(__name__)
-        self.logger.addHandler(handler)
 
         # iterate over the class attributes and log them
         if self.log_level.upper() == "DEBUG":

--- a/hf-provider/tests/unit/common/test_log_bootstrap.py
+++ b/hf-provider/tests/unit/common/test_log_bootstrap.py
@@ -1,0 +1,200 @@
+import json
+import logging
+import logging.handlers
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import warnings
+
+import pytest
+
+from common import log_bootstrap
+
+def _remove_managed_handlers():
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        if isinstance(
+            handler,
+            (log_bootstrap._ProviderLogHandler, log_bootstrap._ProviderNullHandler),
+        ):
+            root_logger.removeHandler(handler)
+            handler.close()
+    logging.captureWarnings(False)
+    
+
+@pytest.fixture(autouse=True)
+def isolate_root_logger():
+    """Isolate the root logger for each test"""
+    _remove_managed_handlers()
+    yield
+    _remove_managed_handlers()
+
+
+def test_default_log_file_honors_hostfactory_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    monkeypatch.setenv("HF_PROVIDER_NAME", "myprovider")
+    monkeypatch.setenv("EGOSC_INSTANCE_HOST", "testhost")
+
+    assert log_bootstrap.default_log_file() == str(
+        tmp_path / "myprovider-provider.testhost.log"
+    )
+
+
+def test_default_log_file_falls_back_to_hostname(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    monkeypatch.delenv("HF_PROVIDER_NAME", raising=False)
+    monkeypatch.delenv("EGOSC_INSTANCE_HOST", raising=False)
+
+    expected = f"gcp-symphony-provider.{socket.gethostname()}.log"
+    assert os.path.basename(log_bootstrap.default_log_file()) == expected
+
+
+def test_default_log_file_matches_wrapper_script_fallback(monkeypatch):
+    monkeypatch.delenv("HF_PROVIDER_LOGDIR", raising=False)
+
+    assert os.path.dirname(log_bootstrap.default_log_file()) == tempfile.gettempdir()
+
+
+def test_bootstrap_routes_warnings_to_log_not_stderr(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    monkeypatch.setenv("EGOSC_INSTANCE_HOST", "testhost")
+    monkeypatch.delenv("HF_PROVIDER_NAME", raising=False)
+
+    log_bootstrap.bootstrap_logging()
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        warnings.warn("synthetic-runtime-warning", FutureWarning)
+    log_bootstrap._installed_handler().flush()
+
+    log_file_path = tmp_path / "gcp-symphony-provider.testhost.log"
+    assert "synthetic-runtime-warning" in log_file_path.read_text()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+def test_bootstrap_is_idempotent(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    root_logger = logging.getLogger()
+    handlers_before = len(root_logger.handlers)
+
+    log_bootstrap.bootstrap_logging()
+    log_bootstrap.bootstrap_logging()
+
+    assert len(root_logger.handlers) == handlers_before + 1
+
+
+def test_bootstrap_falls_back_to_tempdir(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path / "nonexistent_dir"))
+    fallback_dir = tmp_path / "tempdir"
+    fallback_dir.mkdir()
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_dir))
+
+    log_bootstrap.bootstrap_logging()
+
+    handler = log_bootstrap._installed_handler()
+    assert isinstance(handler, logging.handlers.RotatingFileHandler)
+    assert os.path.dirname(handler.baseFilename) == str(fallback_dir)
+
+
+def test_bootstrap_never_attaches_stream_handler(monkeypatch, tmp_path):
+    missing = tmp_path / "missing"
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(missing / "logs"))
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(missing / "tmp"))
+    
+    root_logger = logging.getLogger()
+    handlers_before  = list(root_logger.handlers)
+    log_bootstrap.bootstrap_logging()
+
+    added_handlers = [handler for handler in root_logger.handlers if handler not in handlers_before]
+    assert len(added_handlers) == 1
+    assert isinstance(added_handlers[0], logging.NullHandler)
+
+def test_bootstrap_reinstalls_after_external_handler_removal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+
+    root_logger = logging.getLogger()
+    root_logger.removeHandler(log_bootstrap._installed_handler())
+    assert log_bootstrap._installed_handler() is None
+
+    log_bootstrap.bootstrap_logging()
+    assert log_bootstrap._installed_handler() is not None
+
+
+def test_configure_logging_applies_provider_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+
+    custom_logfile = tmp_path / "custom.log"
+    log_bootstrap.configure_logging(
+        logfile=str(custom_logfile), level="INFO", max_bytes=1024, backup_count=2
+    )
+
+    assert logging.getLogger().level == logging.INFO
+    handler = log_bootstrap._installed_handler()
+    assert os.path.abspath(handler.baseFilename) == os.path.abspath(str(custom_logfile))
+
+    logging.getLogger("contract.test").info("test-info-message")
+    handler.flush()
+    assert "test-info-message" in custom_logfile.read_text()
+
+
+def test_configure_logging_reuses_handler_when_unchanged(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+    handler = log_bootstrap._installed_handler()
+
+    log_bootstrap.configure_logging(
+        logfile=log_bootstrap.default_log_file(),
+        level="WARNING",
+        max_bytes=log_bootstrap.DEFAULT_LOG_MAX_BYTES,
+        backup_count=log_bootstrap.DEFAULT_LOG_BACKUP_COUNT
+    )
+
+    assert log_bootstrap._installed_handler() is handler
+
+
+def test_configure_logging_keeps_old_target_when_new_unwritable(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_PROVIDER_LOGDIR", str(tmp_path))
+    log_bootstrap.bootstrap_logging()
+    old_handler = log_bootstrap._installed_handler()
+
+    log_bootstrap.configure_logging(logfile=str(tmp_path / "missing" / "x.log"))
+
+    assert log_bootstrap._installed_handler() is old_handler
+
+
+def test_import_time_warning_is_captured_end_to_end(tmp_path, src_dir):
+    script = "\n".join(
+        [
+            "from common.log_bootstrap import bootstrap_logging",
+            "bootstrap_logging()",
+            "import warnings",
+            "warnings.warn('synthetic-import-time-warning', FutureWarning)",
+            'print(\'{"ok": true}\')'
+        ]
+    )
+    env = os.environ.copy()
+
+    env.pop("HF_PROVIDER_NAME", None)
+    env.pop("GCP_HF_LOG_LEVEL", None)
+    env["HF_PROVIDER_LOGDIR"] = str(tmp_path)
+    env["EGOSC_INSTANCE_HOST"] = "e2ehost"
+    env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    env["PYTHONWARNINGS"] = "always"
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert json.loads(result.stdout) == {"ok": True}
+    assert result.stderr == ""
+    log_content = (tmp_path / "gcp-symphony-provider.e2ehost.log").read_text()
+    assert "synthetic-import-time-warning" in log_content

--- a/hf-provider/tests/unit/conftest.py
+++ b/hf-provider/tests/unit/conftest.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+
+import pytest
+
+_HF_PROVIDER_ROOT = Path(__file__).parents[2]
+_CONTRACT_HOST = "contract-host"
+
+
+
+@pytest.fixture
+def src_dir() -> Path:
+    return _HF_PROVIDER_ROOT / "src"
+
+
+@pytest.fixture
+def provider_config_dir() -> Path:
+    return (
+        _HF_PROVIDER_ROOT
+        / "tests"
+        / "resources"
+        / "provider-config"
+        / "config-001"
+        / "conf"
+        / "providers"
+    )
+
+
+@pytest.fixture
+def provider_log_name() -> str:
+    return f"gcp-symphony-provider.{_CONTRACT_HOST}.log"
+
+
+@pytest.fixture
+def make_cli_env(src_dir):
+
+    def _make(confdir, log_dir):
+        env = os.environ.copy()
+
+        env.pop("HF_PROVIDER_NAME", None)
+        env.pop("GCP_HF_LOG_LEVEL", None)
+        env["HF_PROVIDER_CONFDIR"] = str(confdir)
+        env["HF_PROVIDER_LOGDIR"] = str(log_dir)
+        env["EGOSC_INSTANCE_HOST"] = _CONTRACT_HOST
+        env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+        env["PYTHONWARNINGS"] = "always"
+
+        return env
+    
+    return _make

--- a/hf-provider/tests/unit/gce_provider/test_client_factory.py
+++ b/hf-provider/tests/unit/gce_provider/test_client_factory.py
@@ -1,0 +1,81 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.oauth2 import service_account
+
+from gce_provider.config import Config
+from gce_provider.utils import client_factory
+
+
+@pytest.fixture(autouse=True)
+def clear_credentials_cache():
+    client_factory.get_credentials.cache_clear()
+
+
+def make_config(credentials_file, conf_dir):
+    config = MagicMock(spec=Config)
+    config.gcp_credentials_file = credentials_file
+    config.hf_provider_conf_dir = conf_dir
+    config.logger = MagicMock()
+    return config
+
+
+def test_returns_none_when_no_credentials_file():
+    """With no credentials file set, fall back to application default credentials."""
+    config = make_config(credentials_file=None, conf_dir="/some/dir")
+    assert client_factory.get_credentials(config) is None
+
+
+def test_uses_global_config_when_none_passed():
+    """When called with no config, load the global config via get_config()."""
+    with patch.object(client_factory, "get_config") as mock_get_config:
+        mock_get_config.return_value = make_config(
+            credentials_file=None, conf_dir="/some/dir"
+        )
+        result = client_factory.get_credentials(None)
+
+    assert result is None
+    mock_get_config.assert_called_once()
+
+
+def test_returns_none_when_file_missing(tmp_path):
+    """Configured-but-missing credentials file falls back to ADC (returns None)."""
+    config = make_config(credentials_file="missing_gcp_credentials_file.json", conf_dir=str(tmp_path))
+    assert client_factory.get_credentials(config) is None
+
+
+def test_resolves_relative_path_against_confdir(tmp_path):
+    """Relative credential path resolves against the provider config directory."""
+    sa_info = {"type": "service_account", "project_id": "test-project"}
+    creds = tmp_path / "test_gcp_credentials_file.json"
+    creds.write_text(json.dumps(sa_info))
+    config = make_config(credentials_file="test_gcp_credentials_file.json", conf_dir=str(tmp_path))
+
+    sentinel = object()
+    with patch.object(
+        service_account.Credentials,
+        "from_service_account_info",
+        return_value=sentinel,
+    ) as mock_from_info:
+       result = client_factory.get_credentials(config)
+
+    assert result is sentinel
+    mock_from_info.assert_called_once_with(sa_info)
+
+
+def test_falls_back_to_none_when_credential_load_fails(tmp_path):
+    """When GCP rejects the key file, swallow, log, and fall back to ADC (returns None)."""
+    creds = tmp_path / "test_gcp_credentials_file.json"
+    creds.write_text("{}")
+    config = make_config(credentials_file="test_gcp_credentials_file.json", conf_dir=str(tmp_path))
+
+    with patch.object(
+        service_account.Credentials,
+        "from_service_account_info",
+        side_effect=ValueError("bad key"),
+    ):
+        result = client_factory.get_credentials(config)
+
+    assert result is None
+    config.logger.exception.assert_called_once()

--- a/hf-provider/tests/unit/gce_provider/test_stdout_contract.py
+++ b/hf-provider/tests/unit/gce_provider/test_stdout_contract.py
@@ -1,0 +1,61 @@
+import json
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+
+@pytest.fixture
+def gce_cli_env(tmp_path, make_cli_env, provider_config_dir):
+    conf_dir = tmp_path / "conf"
+    shutil.copytree(provider_config_dir / "gcpgceinst", conf_dir)
+    config_path = conf_dir / "gcpgceinstprov_config.json"
+    provider_conf = json.loads(config_path.read_text())
+    provider_conf["PUBSUB_AUTOLAUNCH"] = False
+    config_path.write_text(json.dumps(provider_conf))
+
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    env = make_cli_env(conf_dir, log_dir)
+    env["HF_DBDIR"] = str(db_dir)
+    return env, log_dir
+
+
+def test_get_available_templates_is_pure_json(gce_cli_env, provider_log_name):
+    env, log_dir = gce_cli_env
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gce_provider", "getAvailableTemplates"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    parsed = json.loads(result.stdout)
+    assert "templates" in parsed
+    assert result.stderr == ""
+    assert (log_dir / provider_log_name).exists()
+
+
+def test_failure_exits_1_with_error_message_on_stdout(gce_cli_env, provider_log_name):
+    env, log_dir = gce_cli_env
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gce_provider", "requestMachines", "{}"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert result.stdout.startswith("Error:")
+    assert result.stderr == ""
+    assert "Traceback" in (log_dir / provider_log_name).read_text()

--- a/hf-provider/tests/unit/gke_provider/test_stdout_contract.py
+++ b/hf-provider/tests/unit/gke_provider/test_stdout_contract.py
@@ -1,0 +1,41 @@
+import json
+import subprocess
+import sys
+
+def test_get_available_templates_stdout_is_pure_json(
+    tmp_path, make_cli_env, provider_config_dir, provider_log_name
+):
+    env = make_cli_env(provider_config_dir / "gcpgkeinst", tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gke_provider", "getAvailableTemplates"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    parsed = json.loads(result.stdout)
+    assert "templates" in parsed
+    assert result.stderr == ""
+    assert (tmp_path / provider_log_name).exists()
+
+
+def test_failure_exits_1_with_error_message_on_stdout(
+        tmp_path, make_cli_env, provider_config_dir, provider_log_name
+):
+    env = make_cli_env(provider_config_dir / "gcpgkeinst", tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "gke_provider", "requestMachines", "{}"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180
+    )
+
+    assert result.returncode == 1, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert result.stdout.startswith("Error:")
+    assert result.stderr == ""
+    assert "Traceback" in (tmp_path / provider_log_name).read_text()

--- a/hf-provider/uv.lock
+++ b/hf-provider/uv.lock
@@ -1,82 +1,82 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = "==3.9.*"
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
 name = "cachetools"
 version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276 },
+    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286 },
+    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371 }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/ca/9a0983dd5c8e9733565cf3db4df2b0a2e9a82659fd8aa2a868ac6e4a991f/charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05", size = 207520 },
-    { url = "https://files.pythonhosted.org/packages/39/c6/99271dc37243a4f925b09090493fb96c9333d7992c6187f5cfe5312008d2/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e", size = 147307 },
-    { url = "https://files.pythonhosted.org/packages/e4/69/132eab043356bba06eb333cc2cc60c6340857d0a2e4ca6dc2b51312886b3/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99", size = 160448 },
-    { url = "https://files.pythonhosted.org/packages/04/9a/914d294daa4809c57667b77470533e65def9c0be1ef8b4c1183a99170e9d/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7", size = 157758 },
-    { url = "https://files.pythonhosted.org/packages/b0/a8/6f5bcf1bcf63cb45625f7c5cadca026121ff8a6c8a3256d8d8cd59302663/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7", size = 152487 },
-    { url = "https://files.pythonhosted.org/packages/c4/72/d3d0e9592f4e504f9dea08b8db270821c909558c353dc3b457ed2509f2fb/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19", size = 150054 },
-    { url = "https://files.pythonhosted.org/packages/20/30/5f64fe3981677fe63fa987b80e6c01042eb5ff653ff7cec1b7bd9268e54e/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312", size = 161703 },
-    { url = "https://files.pythonhosted.org/packages/e1/ef/dd08b2cac9284fd59e70f7d97382c33a3d0a926e45b15fc21b3308324ffd/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc", size = 159096 },
-    { url = "https://files.pythonhosted.org/packages/45/8c/dcef87cfc2b3f002a6478f38906f9040302c68aebe21468090e39cde1445/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34", size = 153852 },
-    { url = "https://files.pythonhosted.org/packages/63/86/9cbd533bd37883d467fcd1bd491b3547a3532d0fbb46de2b99feeebf185e/charset_normalizer-3.4.3-cp39-cp39-win32.whl", hash = "sha256:16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432", size = 99840 },
-    { url = "https://files.pythonhosted.org/packages/ce/d6/7e805c8e5c46ff9729c49950acc4ee0aeb55efb8b3a56687658ad10c3216/charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca", size = 107438 },
-    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175 },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/9a0983dd5c8e9733565cf3db4df2b0a2e9a82659fd8aa2a868ac6e4a991f/charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05", size = 207520, upload-time = "2025-08-09T07:57:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/99271dc37243a4f925b09090493fb96c9333d7992c6187f5cfe5312008d2/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e", size = 147307, upload-time = "2025-08-09T07:57:12.4Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/69/132eab043356bba06eb333cc2cc60c6340857d0a2e4ca6dc2b51312886b3/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99", size = 160448, upload-time = "2025-08-09T07:57:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/914d294daa4809c57667b77470533e65def9c0be1ef8b4c1183a99170e9d/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7", size = 157758, upload-time = "2025-08-09T07:57:14.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a8/6f5bcf1bcf63cb45625f7c5cadca026121ff8a6c8a3256d8d8cd59302663/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7", size = 152487, upload-time = "2025-08-09T07:57:16.332Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/d3d0e9592f4e504f9dea08b8db270821c909558c353dc3b457ed2509f2fb/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19", size = 150054, upload-time = "2025-08-09T07:57:17.576Z" },
+    { url = "https://files.pythonhosted.org/packages/20/30/5f64fe3981677fe63fa987b80e6c01042eb5ff653ff7cec1b7bd9268e54e/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312", size = 161703, upload-time = "2025-08-09T07:57:20.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ef/dd08b2cac9284fd59e70f7d97382c33a3d0a926e45b15fc21b3308324ffd/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc", size = 159096, upload-time = "2025-08-09T07:57:21.329Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8c/dcef87cfc2b3f002a6478f38906f9040302c68aebe21468090e39cde1445/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34", size = 153852, upload-time = "2025-08-09T07:57:22.608Z" },
+    { url = "https://files.pythonhosted.org/packages/63/86/9cbd533bd37883d467fcd1bd491b3547a3532d0fbb46de2b99feeebf185e/charset_normalizer-3.4.3-cp39-cp39-win32.whl", hash = "sha256:16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432", size = 99840, upload-time = "2025-08-09T07:57:23.883Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d6/7e805c8e5c46ff9729c49950acc4ee0aeb55efb8b3a56687658ad10c3216/charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca", size = 107438, upload-time = "2025-08-09T07:57:25.287Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "coverage"
 version = "7.10.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704 }
+sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3", size = 217978 },
-    { url = "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c", size = 218370 },
-    { url = "https://files.pythonhosted.org/packages/dd/6e/30d006c3b469e58449650642383dddf1c8fb63d44fdf92994bfd46570695/coverage-7.10.7-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396", size = 244802 },
-    { url = "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40", size = 246625 },
-    { url = "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594", size = 248399 },
-    { url = "https://files.pythonhosted.org/packages/c0/54/b140edee7257e815de7426d5d9846b58505dffc29795fff2dfb7f8a1c5a0/coverage-7.10.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a", size = 245142 },
-    { url = "https://files.pythonhosted.org/packages/e4/9e/6d6b8295940b118e8b7083b29226c71f6154f7ff41e9ca431f03de2eac0d/coverage-7.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b", size = 246284 },
-    { url = "https://files.pythonhosted.org/packages/db/e5/5e957ca747d43dbe4d9714358375c7546cb3cb533007b6813fc20fce37ad/coverage-7.10.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3", size = 244353 },
-    { url = "https://files.pythonhosted.org/packages/9a/45/540fc5cc92536a1b783b7ef99450bd55a4b3af234aae35a18a339973ce30/coverage-7.10.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0", size = 244430 },
-    { url = "https://files.pythonhosted.org/packages/75/0b/8287b2e5b38c8fe15d7e3398849bb58d382aedc0864ea0fa1820e8630491/coverage-7.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f", size = 245311 },
-    { url = "https://files.pythonhosted.org/packages/0c/1d/29724999984740f0c86d03e6420b942439bf5bd7f54d4382cae386a9d1e9/coverage-7.10.7-cp39-cp39-win32.whl", hash = "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431", size = 220500 },
-    { url = "https://files.pythonhosted.org/packages/43/11/4b1e6b129943f905ca54c339f343877b55b365ae2558806c1be4f7476ed5/coverage-7.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07", size = 221408 },
-    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952 },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3", size = 217978, upload-time = "2025-09-21T20:03:30.362Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c", size = 218370, upload-time = "2025-09-21T20:03:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6e/30d006c3b469e58449650642383dddf1c8fb63d44fdf92994bfd46570695/coverage-7.10.7-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396", size = 244802, upload-time = "2025-09-21T20:03:33.919Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40", size = 246625, upload-time = "2025-09-21T20:03:36.09Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594", size = 248399, upload-time = "2025-09-21T20:03:38.342Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/54/b140edee7257e815de7426d5d9846b58505dffc29795fff2dfb7f8a1c5a0/coverage-7.10.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a", size = 245142, upload-time = "2025-09-21T20:03:40.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/9e/6d6b8295940b118e8b7083b29226c71f6154f7ff41e9ca431f03de2eac0d/coverage-7.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b", size = 246284, upload-time = "2025-09-21T20:03:42.355Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/5e957ca747d43dbe4d9714358375c7546cb3cb533007b6813fc20fce37ad/coverage-7.10.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3", size = 244353, upload-time = "2025-09-21T20:03:44.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/45/540fc5cc92536a1b783b7ef99450bd55a4b3af234aae35a18a339973ce30/coverage-7.10.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0", size = 244430, upload-time = "2025-09-21T20:03:46.065Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0b/8287b2e5b38c8fe15d7e3398849bb58d382aedc0864ea0fa1820e8630491/coverage-7.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f", size = 245311, upload-time = "2025-09-21T20:03:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1d/29724999984740f0c86d03e6420b942439bf5bd7f54d4382cae386a9d1e9/coverage-7.10.7-cp39-cp39-win32.whl", hash = "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431", size = 220500, upload-time = "2025-09-21T20:03:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/43/11/4b1e6b129943f905ca54c339f343877b55b365ae2558806c1be4f7476ed5/coverage-7.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07", size = 221408, upload-time = "2025-09-21T20:03:51.803Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
 ]
 
 [package.optional-dependencies]
@@ -88,9 +88,9 @@ toml = [
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922 },
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -100,9 +100,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674 },
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
 ]
 
 [[package]]
@@ -116,9 +116,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/cd/63f1557235c2440fe0577acdbc32577c5c002684c58c7f4d770a92366a24/google_api_core-2.25.2.tar.gz", hash = "sha256:1c63aa6af0d0d5e37966f157a77f9396d820fba59f9e43e9415bc3dc5baff300", size = 166266 }
+sdist = { url = "https://files.pythonhosted.org/packages/09/cd/63f1557235c2440fe0577acdbc32577c5c002684c58c7f4d770a92366a24/google_api_core-2.25.2.tar.gz", hash = "sha256:1c63aa6af0d0d5e37966f157a77f9396d820fba59f9e43e9415bc3dc5baff300", size = 166266, upload-time = "2025-10-03T00:07:34.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/d8/894716a5423933f5c8d2d5f04b16f052a515f78e815dab0c2c6f1fd105dc/google_api_core-2.25.2-py3-none-any.whl", hash = "sha256:e9a8f62d363dc8424a8497f4c2a47d6bcda6c16514c935629c257ab5d10210e7", size = 162489 },
+    { url = "https://files.pythonhosted.org/packages/c8/d8/894716a5423933f5c8d2d5f04b16f052a515f78e815dab0c2c6f1fd105dc/google_api_core-2.25.2-py3-none-any.whl", hash = "sha256:e9a8f62d363dc8424a8497f4c2a47d6bcda6c16514c935629c257ab5d10210e7", size = 162489, upload-time = "2025-10-03T00:07:32.924Z" },
 ]
 
 [package.optional-dependencies]
@@ -136,9 +136,9 @@ dependencies = [
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/af/5129ce5b2f9688d2fa49b463e544972a7c82b0fdb50980dafee92e121d9f/google_auth-2.41.1.tar.gz", hash = "sha256:b76b7b1f9e61f0cb7e88870d14f6a94aeef248959ef6992670efee37709cbfd2", size = 292284 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/af/5129ce5b2f9688d2fa49b463e544972a7c82b0fdb50980dafee92e121d9f/google_auth-2.41.1.tar.gz", hash = "sha256:b76b7b1f9e61f0cb7e88870d14f6a94aeef248959ef6992670efee37709cbfd2", size = 292284, upload-time = "2025-09-30T22:51:26.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/a4/7319a2a8add4cc352be9e3efeff5e2aacee917c85ca2fa1647e29089983c/google_auth-2.41.1-py2.py3-none-any.whl", hash = "sha256:754843be95575b9a19c604a848a41be03f7f2afd8c019f716dc1f51ee41c639d", size = 221302 },
+    { url = "https://files.pythonhosted.org/packages/be/a4/7319a2a8add4cc352be9e3efeff5e2aacee917c85ca2fa1647e29089983c/google_auth-2.41.1-py2.py3-none-any.whl", hash = "sha256:754843be95575b9a19c604a848a41be03f7f2afd8c019f716dc1f51ee41c639d", size = 221302, upload-time = "2025-09-30T22:51:24.212Z" },
 ]
 
 [[package]]
@@ -151,9 +151,9 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/e2/ca2e1076186b5bf0ad767ea8a412f9f374a6f60c5f4743ce8e7e351b3243/google_cloud_compute-1.39.0.tar.gz", hash = "sha256:e91f88d054d3eced8449c331c72f0b595d8529631eae1800e953eaa1080eac0f", size = 4449745 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/e2/ca2e1076186b5bf0ad767ea8a412f9f374a6f60c5f4743ce8e7e351b3243/google_cloud_compute-1.39.0.tar.gz", hash = "sha256:e91f88d054d3eced8449c331c72f0b595d8529631eae1800e953eaa1080eac0f", size = 4449745, upload-time = "2025-10-07T21:28:38.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/36/5c8aab12941c5e14487ecdce68c38c1ec6857aede7018f8759e421344d8d/google_cloud_compute-1.39.0-py3-none-any.whl", hash = "sha256:8a153497fd814728d511f7f9f995039942f5c3b5d6d9df4bc9116ec5ee6d81b3", size = 3431872 },
+    { url = "https://files.pythonhosted.org/packages/1d/36/5c8aab12941c5e14487ecdce68c38c1ec6857aede7018f8759e421344d8d/google_cloud_compute-1.39.0-py3-none-any.whl", hash = "sha256:8a153497fd814728d511f7f9f995039942f5c3b5d6d9df4bc9116ec5ee6d81b3", size = 3431872, upload-time = "2025-10-07T21:28:23.855Z" },
 ]
 
 [[package]]
@@ -171,14 +171,14 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/5a/6142bc0754cb6f3ed330d58a28e07810539dcab23662be932a532e3f249b/google_cloud_pubsub-2.31.1.tar.gz", hash = "sha256:f4214f692da435afcdfb41e77cfa962238db96e4a4ba64637aaa710442d9c532", size = 391409 }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/5a/6142bc0754cb6f3ed330d58a28e07810539dcab23662be932a532e3f249b/google_cloud_pubsub-2.31.1.tar.gz", hash = "sha256:f4214f692da435afcdfb41e77cfa962238db96e4a4ba64637aaa710442d9c532", size = 391409, upload-time = "2025-07-28T21:18:37.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/96/b96c03726126c71b5b7526176feb3114db3323550ab5d1b6d43673378bbc/google_cloud_pubsub-2.31.1-py3-none-any.whl", hash = "sha256:85e9ee330874d725dacf20d65efd52e5ec04141ca04f023d135b961a68b372b0", size = 319167 },
+    { url = "https://files.pythonhosted.org/packages/25/96/b96c03726126c71b5b7526176feb3114db3323550ab5d1b6d43673378bbc/google_cloud_pubsub-2.31.1-py3-none-any.whl", hash = "sha256:85e9ee330874d725dacf20d65efd52e5ec04141ca04f023d135b961a68b372b0", size = 319167, upload-time = "2025-07-28T21:18:35.412Z" },
 ]
 
 [[package]]
 name = "google-symphony-hf"
-version = "0.3.5"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },
@@ -229,9 +229,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903 }
+sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530 },
+    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530, upload-time = "2025-04-14T10:17:01.271Z" },
 ]
 
 [package.optional-dependencies]
@@ -248,9 +248,9 @@ dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/4e/8d0ca3b035e41fe0b3f31ebbb638356af720335e5a11154c330169b40777/grpc_google_iam_v1-0.14.2.tar.gz", hash = "sha256:b3e1fc387a1a329e41672197d0ace9de22c78dd7d215048c4c78712073f7bd20", size = 16259 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/4e/8d0ca3b035e41fe0b3f31ebbb638356af720335e5a11154c330169b40777/grpc_google_iam_v1-0.14.2.tar.gz", hash = "sha256:b3e1fc387a1a329e41672197d0ace9de22c78dd7d215048c4c78712073f7bd20", size = 16259, upload-time = "2025-03-17T11:40:23.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/6f/dd9b178aee7835b96c2e63715aba6516a9d50f6bebbd1cc1d32c82a2a6c3/grpc_google_iam_v1-0.14.2-py3-none-any.whl", hash = "sha256:a3171468459770907926d56a440b2bb643eec1d7ba215f48f3ecece42b4d8351", size = 19242 },
+    { url = "https://files.pythonhosted.org/packages/66/6f/dd9b178aee7835b96c2e63715aba6516a9d50f6bebbd1cc1d32c82a2a6c3/grpc_google_iam_v1-0.14.2-py3-none-any.whl", hash = "sha256:a3171468459770907926d56a440b2bb643eec1d7ba215f48f3ecece42b4d8351", size = 19242, upload-time = "2025-03-17T11:40:22.648Z" },
 ]
 
 [[package]]
@@ -260,18 +260,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/f7/8963848164c7604efb3a3e6ee457fdb3a469653e19002bd24742473254f8/grpcio-1.75.1.tar.gz", hash = "sha256:3e81d89ece99b9ace23a6916880baca613c03a799925afb2857887efa8b1b3d2", size = 12731327 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/f7/8963848164c7604efb3a3e6ee457fdb3a469653e19002bd24742473254f8/grpcio-1.75.1.tar.gz", hash = "sha256:3e81d89ece99b9ace23a6916880baca613c03a799925afb2857887efa8b1b3d2", size = 12731327, upload-time = "2025-09-26T09:03:36.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/e2/33efd823a879dc7b60c10192df1900ee5c200f8e782663a41a3b2aecd143/grpcio-1.75.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:c09fba33327c3ac11b5c33dbdd8218eef8990d78f83b1656d628831812a8c0fb", size = 5706679 },
-    { url = "https://files.pythonhosted.org/packages/5f/13/17e39ee4897f1cd12dd463e863b830e64643b13e9a4af5062b4a6f0790be/grpcio-1.75.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:7e21400b037be29545704889e72e586c238e346dcb2d08d8a7288d16c883a9ec", size = 11490271 },
-    { url = "https://files.pythonhosted.org/packages/77/90/b80e75f8cce758425b2772742eed4e9db765a965d902ba4b7f239b2513de/grpcio-1.75.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c12121e509b9f8b0914d10054d24120237d19e870b1cd82acbb8a9b9ddd198a3", size = 6291926 },
-    { url = "https://files.pythonhosted.org/packages/40/5f/e6033d8f99063350e20873a46225468b73045b9ef2c8cba73d66a87c3fd5/grpcio-1.75.1-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:73577a93e692b3474b1bfe84285d098de36705dbd838bb4d6a056d326e4dc880", size = 6950040 },
-    { url = "https://files.pythonhosted.org/packages/01/12/34076c079b45af5aed40f037fffe388d7fbe90dd539ed01e4744c926d227/grpcio-1.75.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e19e7dfa0d7ca7dea22be464339e18ac608fd75d88c56770c646cdabe54bc724", size = 6465780 },
-    { url = "https://files.pythonhosted.org/packages/e4/c5/ee6fd69a9f6e7288d04da010ad7480a0566d2aac81097ff4dafbc5ffa9b6/grpcio-1.75.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e1c28f51c1cf67eccdfc1065e8e866c9ed622f09773ca60947089c117f848a1", size = 7098308 },
-    { url = "https://files.pythonhosted.org/packages/78/32/f2be13f13035361768923159fe20470a7d22db2c7c692b952e21284f56e5/grpcio-1.75.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:030a6164bc2ca726052778c0cf8e3249617a34e368354f9e6107c27ad4af8c28", size = 8042268 },
-    { url = "https://files.pythonhosted.org/packages/e7/2d/1bb0572f0a2eaab100b4635c6c2cd0d37e3cda5554037e3f90b1bc428d56/grpcio-1.75.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:67697efef5a98d46d5db7b1720fa4043536f8b8e5072a5d61cfca762f287e939", size = 7491470 },
-    { url = "https://files.pythonhosted.org/packages/aa/e0/1e962dcb64019bbd87eedcfacdedb83af0f66da01f2f6e03d69b0aa1b7f0/grpcio-1.75.1-cp39-cp39-win32.whl", hash = "sha256:52015cf73eb5d76f6404e0ce0505a69b51fd1f35810b3a01233b34b10baafb41", size = 3951697 },
-    { url = "https://files.pythonhosted.org/packages/87/bc/47fb3aaa77e7d657999937ec1026beba9e37f3199599fe510f762d31da97/grpcio-1.75.1-cp39-cp39-win_amd64.whl", hash = "sha256:9fe51e4a1f896ea84ac750900eae34d9e9b896b5b1e4a30b02dc31ad29f36383", size = 4645764 },
+    { url = "https://files.pythonhosted.org/packages/8f/e2/33efd823a879dc7b60c10192df1900ee5c200f8e782663a41a3b2aecd143/grpcio-1.75.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:c09fba33327c3ac11b5c33dbdd8218eef8990d78f83b1656d628831812a8c0fb", size = 5706679, upload-time = "2025-09-26T09:03:10.218Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/17e39ee4897f1cd12dd463e863b830e64643b13e9a4af5062b4a6f0790be/grpcio-1.75.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:7e21400b037be29545704889e72e586c238e346dcb2d08d8a7288d16c883a9ec", size = 11490271, upload-time = "2025-09-26T09:03:12.778Z" },
+    { url = "https://files.pythonhosted.org/packages/77/90/b80e75f8cce758425b2772742eed4e9db765a965d902ba4b7f239b2513de/grpcio-1.75.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c12121e509b9f8b0914d10054d24120237d19e870b1cd82acbb8a9b9ddd198a3", size = 6291926, upload-time = "2025-09-26T09:03:16.282Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5f/e6033d8f99063350e20873a46225468b73045b9ef2c8cba73d66a87c3fd5/grpcio-1.75.1-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:73577a93e692b3474b1bfe84285d098de36705dbd838bb4d6a056d326e4dc880", size = 6950040, upload-time = "2025-09-26T09:03:18.874Z" },
+    { url = "https://files.pythonhosted.org/packages/01/12/34076c079b45af5aed40f037fffe388d7fbe90dd539ed01e4744c926d227/grpcio-1.75.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e19e7dfa0d7ca7dea22be464339e18ac608fd75d88c56770c646cdabe54bc724", size = 6465780, upload-time = "2025-09-26T09:03:21.219Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c5/ee6fd69a9f6e7288d04da010ad7480a0566d2aac81097ff4dafbc5ffa9b6/grpcio-1.75.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e1c28f51c1cf67eccdfc1065e8e866c9ed622f09773ca60947089c117f848a1", size = 7098308, upload-time = "2025-09-26T09:03:23.875Z" },
+    { url = "https://files.pythonhosted.org/packages/78/32/f2be13f13035361768923159fe20470a7d22db2c7c692b952e21284f56e5/grpcio-1.75.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:030a6164bc2ca726052778c0cf8e3249617a34e368354f9e6107c27ad4af8c28", size = 8042268, upload-time = "2025-09-26T09:03:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2d/1bb0572f0a2eaab100b4635c6c2cd0d37e3cda5554037e3f90b1bc428d56/grpcio-1.75.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:67697efef5a98d46d5db7b1720fa4043536f8b8e5072a5d61cfca762f287e939", size = 7491470, upload-time = "2025-09-26T09:03:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e0/1e962dcb64019bbd87eedcfacdedb83af0f66da01f2f6e03d69b0aa1b7f0/grpcio-1.75.1-cp39-cp39-win32.whl", hash = "sha256:52015cf73eb5d76f6404e0ce0505a69b51fd1f35810b3a01233b34b10baafb41", size = 3951697, upload-time = "2025-09-26T09:03:31.535Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/47fb3aaa77e7d657999937ec1026beba9e37f3199599fe510f762d31da97/grpcio-1.75.1-cp39-cp39-win_amd64.whl", hash = "sha256:9fe51e4a1f896ea84ac750900eae34d9e9b896b5b1e4a30b02dc31ad29f36383", size = 4645764, upload-time = "2025-09-26T09:03:34.071Z" },
 ]
 
 [[package]]
@@ -283,18 +283,18 @@ dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/5b/1ce0e3eedcdc08b4739b3da5836f31142ec8bee1a9ae0ad8dc0dc39a14bf/grpcio_status-1.75.1.tar.gz", hash = "sha256:8162afa21833a2085c91089cc395ad880fac1378a1d60233d976649ed724cbf8", size = 13671 }
+sdist = { url = "https://files.pythonhosted.org/packages/74/5b/1ce0e3eedcdc08b4739b3da5836f31142ec8bee1a9ae0ad8dc0dc39a14bf/grpcio_status-1.75.1.tar.gz", hash = "sha256:8162afa21833a2085c91089cc395ad880fac1378a1d60233d976649ed724cbf8", size = 13671, upload-time = "2025-09-26T09:13:16.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/ad/6f414bb0b36eee20d93af6907256f208ffcda992ae6d3d7b6a778afe31e6/grpcio_status-1.75.1-py3-none-any.whl", hash = "sha256:f681b301be26dcf7abf5c765d4a22e4098765e1a65cbdfa3efca384edf8e4e3c", size = 14428 },
+    { url = "https://files.pythonhosted.org/packages/d8/ad/6f414bb0b36eee20d93af6907256f208ffcda992ae6d3d7b6a778afe31e6/grpcio_status-1.75.1-py3-none-any.whl", hash = "sha256:f681b301be26dcf7abf5c765d4a22e4098765e1a65cbdfa3efca384edf8e4e3c", size = 14428, upload-time = "2025-09-26T09:12:55.516Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
@@ -304,18 +304,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656 },
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -335,18 +335,18 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691 }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691, upload-time = "2025-02-18T21:06:34.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070 },
+    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070, upload-time = "2025-02-18T21:06:31.391Z" },
 ]
 
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918 }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065 },
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -357,9 +357,9 @@ dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/04/05040d7ce33a907a2a02257e601992f0cdf11c73b33f13c4492bf6c3d6d5/opentelemetry_api-1.37.0.tar.gz", hash = "sha256:540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7", size = 64923 }
+sdist = { url = "https://files.pythonhosted.org/packages/63/04/05040d7ce33a907a2a02257e601992f0cdf11c73b33f13c4492bf6c3d6d5/opentelemetry_api-1.37.0.tar.gz", hash = "sha256:540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7", size = 64923, upload-time = "2025-09-11T10:29:01.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/48/28ed9e55dcf2f453128df738210a980e09f4e468a456fa3c763dbc8be70a/opentelemetry_api-1.37.0-py3-none-any.whl", hash = "sha256:accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47", size = 65732 },
+    { url = "https://files.pythonhosted.org/packages/91/48/28ed9e55dcf2f453128df738210a980e09f4e468a456fa3c763dbc8be70a/opentelemetry_api-1.37.0-py3-none-any.whl", hash = "sha256:accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47", size = 65732, upload-time = "2025-09-11T10:28:41.826Z" },
 ]
 
 [[package]]
@@ -371,9 +371,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/62/2e0ca80d7fe94f0b193135375da92c640d15fe81f636658d2acf373086bc/opentelemetry_sdk-1.37.0.tar.gz", hash = "sha256:cc8e089c10953ded765b5ab5669b198bbe0af1b3f89f1007d19acd32dc46dda5", size = 170404 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/62/2e0ca80d7fe94f0b193135375da92c640d15fe81f636658d2acf373086bc/opentelemetry_sdk-1.37.0.tar.gz", hash = "sha256:cc8e089c10953ded765b5ab5669b198bbe0af1b3f89f1007d19acd32dc46dda5", size = 170404, upload-time = "2025-09-11T10:29:11.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/62/9f4ad6a54126fb00f7ed4bb5034964c6e4f00fcd5a905e115bd22707e20d/opentelemetry_sdk-1.37.0-py3-none-any.whl", hash = "sha256:8f3c3c22063e52475c5dbced7209495c2c16723d016d39287dfc215d1771257c", size = 131941 },
+    { url = "https://files.pythonhosted.org/packages/9f/62/9f4ad6a54126fb00f7ed4bb5034964c6e4f00fcd5a905e115bd22707e20d/opentelemetry_sdk-1.37.0-py3-none-any.whl", hash = "sha256:8f3c3c22063e52475c5dbced7209495c2c16723d016d39287dfc215d1771257c", size = 131941, upload-time = "2025-09-11T10:28:57.83Z" },
 ]
 
 [[package]]
@@ -384,27 +384,27 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867, upload-time = "2025-09-11T10:29:12.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954 },
+    { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954, upload-time = "2025-09-11T10:28:59.218Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -414,34 +414,34 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163 },
+    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163, upload-time = "2025-03-10T15:54:37.335Z" },
 ]
 
 [[package]]
 name = "protobuf"
 version = "6.32.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/a4/cc17347aa2897568beece2e674674359f911d6fe21b0b8d6268cd42727ac/protobuf-6.32.1.tar.gz", hash = "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d", size = 440635 }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/a4/cc17347aa2897568beece2e674674359f911d6fe21b0b8d6268cd42727ac/protobuf-6.32.1.tar.gz", hash = "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d", size = 440635, upload-time = "2025-09-11T21:38:42.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/98/645183ea03ab3995d29086b8bf4f7562ebd3d10c9a4b14ee3f20d47cfe50/protobuf-6.32.1-cp310-abi3-win32.whl", hash = "sha256:a8a32a84bc9f2aad712041b8b366190f71dde248926da517bde9e832e4412085", size = 424411 },
-    { url = "https://files.pythonhosted.org/packages/8c/f3/6f58f841f6ebafe076cebeae33fc336e900619d34b1c93e4b5c97a81fdfa/protobuf-6.32.1-cp310-abi3-win_amd64.whl", hash = "sha256:b00a7d8c25fa471f16bc8153d0e53d6c9e827f0953f3c09aaa4331c718cae5e1", size = 435738 },
-    { url = "https://files.pythonhosted.org/packages/10/56/a8a3f4e7190837139e68c7002ec749190a163af3e330f65d90309145a210/protobuf-6.32.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281", size = 426454 },
-    { url = "https://files.pythonhosted.org/packages/3f/be/8dd0a927c559b37d7a6c8ab79034fd167dcc1f851595f2e641ad62be8643/protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4", size = 322874 },
-    { url = "https://files.pythonhosted.org/packages/5c/f6/88d77011b605ef979aace37b7703e4eefad066f7e84d935e5a696515c2dd/protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710", size = 322013 },
-    { url = "https://files.pythonhosted.org/packages/05/9d/d6f1a8b6657296920c58f6b85f7bca55fa27e3ca7fc5914604d89cd0250b/protobuf-6.32.1-cp39-cp39-win32.whl", hash = "sha256:68ff170bac18c8178f130d1ccb94700cf72852298e016a2443bdb9502279e5f1", size = 424505 },
-    { url = "https://files.pythonhosted.org/packages/ed/cd/891bd2d23558f52392a5687b2406a741e2e28d629524c88aade457029acd/protobuf-6.32.1-cp39-cp39-win_amd64.whl", hash = "sha256:d0975d0b2f3e6957111aa3935d08a0eb7e006b1505d825f862a1fffc8348e122", size = 435825 },
-    { url = "https://files.pythonhosted.org/packages/97/b7/15cc7d93443d6c6a84626ae3258a91f4c6ac8c0edd5df35ea7658f71b79c/protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346", size = 169289 },
+    { url = "https://files.pythonhosted.org/packages/c0/98/645183ea03ab3995d29086b8bf4f7562ebd3d10c9a4b14ee3f20d47cfe50/protobuf-6.32.1-cp310-abi3-win32.whl", hash = "sha256:a8a32a84bc9f2aad712041b8b366190f71dde248926da517bde9e832e4412085", size = 424411, upload-time = "2025-09-11T21:38:27.427Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f3/6f58f841f6ebafe076cebeae33fc336e900619d34b1c93e4b5c97a81fdfa/protobuf-6.32.1-cp310-abi3-win_amd64.whl", hash = "sha256:b00a7d8c25fa471f16bc8153d0e53d6c9e827f0953f3c09aaa4331c718cae5e1", size = 435738, upload-time = "2025-09-11T21:38:30.959Z" },
+    { url = "https://files.pythonhosted.org/packages/10/56/a8a3f4e7190837139e68c7002ec749190a163af3e330f65d90309145a210/protobuf-6.32.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281", size = 426454, upload-time = "2025-09-11T21:38:34.076Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/be/8dd0a927c559b37d7a6c8ab79034fd167dcc1f851595f2e641ad62be8643/protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4", size = 322874, upload-time = "2025-09-11T21:38:35.509Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f6/88d77011b605ef979aace37b7703e4eefad066f7e84d935e5a696515c2dd/protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710", size = 322013, upload-time = "2025-09-11T21:38:37.017Z" },
+    { url = "https://files.pythonhosted.org/packages/05/9d/d6f1a8b6657296920c58f6b85f7bca55fa27e3ca7fc5914604d89cd0250b/protobuf-6.32.1-cp39-cp39-win32.whl", hash = "sha256:68ff170bac18c8178f130d1ccb94700cf72852298e016a2443bdb9502279e5f1", size = 424505, upload-time = "2025-09-11T21:38:38.415Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cd/891bd2d23558f52392a5687b2406a741e2e28d629524c88aade457029acd/protobuf-6.32.1-cp39-cp39-win_amd64.whl", hash = "sha256:d0975d0b2f3e6957111aa3935d08a0eb7e006b1505d825f862a1fffc8348e122", size = 435825, upload-time = "2025-09-11T21:38:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b7/15cc7d93443d6c6a84626ae3258a91f4c6ac8c0edd5df35ea7658f71b79c/protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346", size = 169289, upload-time = "2025-09-11T21:38:41.234Z" },
 ]
 
 [[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322 }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135 },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
 ]
 
 [[package]]
@@ -451,9 +451,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -466,9 +466,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540, upload-time = "2025-04-29T20:38:55.02Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/12/46b65f3534d099349e38ef6ec98b1a5a81f42536d17e0ba382c28c67ba67/pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb", size = 443900 },
+    { url = "https://files.pythonhosted.org/packages/e7/12/46b65f3534d099349e38ef6ec98b1a5a81f42536d17e0ba382c28c67ba67/pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb", size = 443900, upload-time = "2025-04-29T20:38:52.724Z" },
 ]
 
 [[package]]
@@ -478,39 +478,39 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/ea/bbe9095cdd771987d13c82d104a9c8559ae9aec1e29f139e286fd2e9256e/pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d", size = 2028677 },
-    { url = "https://files.pythonhosted.org/packages/49/1d/4ac5ed228078737d457a609013e8f7edc64adc37b91d619ea965758369e5/pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954", size = 1864735 },
-    { url = "https://files.pythonhosted.org/packages/23/9a/2e70d6388d7cda488ae38f57bc2f7b03ee442fbcf0d75d848304ac7e405b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb", size = 1898467 },
-    { url = "https://files.pythonhosted.org/packages/ff/2e/1568934feb43370c1ffb78a77f0baaa5a8b6897513e7a91051af707ffdc4/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7", size = 1983041 },
-    { url = "https://files.pythonhosted.org/packages/01/1a/1a1118f38ab64eac2f6269eb8c120ab915be30e387bb561e3af904b12499/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4", size = 2136503 },
-    { url = "https://files.pythonhosted.org/packages/5c/da/44754d1d7ae0f22d6d3ce6c6b1486fc07ac2c524ed8f6eca636e2e1ee49b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b", size = 2736079 },
-    { url = "https://files.pythonhosted.org/packages/4d/98/f43cd89172220ec5aa86654967b22d862146bc4d736b1350b4c41e7c9c03/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3", size = 2006508 },
-    { url = "https://files.pythonhosted.org/packages/2b/cc/f77e8e242171d2158309f830f7d5d07e0531b756106f36bc18712dc439df/pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a", size = 2113693 },
-    { url = "https://files.pythonhosted.org/packages/54/7a/7be6a7bd43e0a47c147ba7fbf124fe8aaf1200bc587da925509641113b2d/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782", size = 2074224 },
-    { url = "https://files.pythonhosted.org/packages/2a/07/31cf8fadffbb03be1cb520850e00a8490c0927ec456e8293cafda0726184/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9", size = 2245403 },
-    { url = "https://files.pythonhosted.org/packages/b6/8d/bbaf4c6721b668d44f01861f297eb01c9b35f612f6b8e14173cb204e6240/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e", size = 2242331 },
-    { url = "https://files.pythonhosted.org/packages/bb/93/3cc157026bca8f5006250e74515119fcaa6d6858aceee8f67ab6dc548c16/pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9", size = 1910571 },
-    { url = "https://files.pythonhosted.org/packages/5b/90/7edc3b2a0d9f0dda8806c04e511a67b0b7a41d2187e2003673a996fb4310/pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3", size = 1956504 },
-    { url = "https://files.pythonhosted.org/packages/08/98/dbf3fdfabaf81cda5622154fda78ea9965ac467e3239078e0dcd6df159e7/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101", size = 2024034 },
-    { url = "https://files.pythonhosted.org/packages/8d/99/7810aa9256e7f2ccd492590f86b79d370df1e9292f1f80b000b6a75bd2fb/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64", size = 1858578 },
-    { url = "https://files.pythonhosted.org/packages/d8/60/bc06fa9027c7006cc6dd21e48dbf39076dc39d9abbaf718a1604973a9670/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d", size = 1892858 },
-    { url = "https://files.pythonhosted.org/packages/f2/40/9d03997d9518816c68b4dfccb88969756b9146031b61cd37f781c74c9b6a/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535", size = 2068498 },
-    { url = "https://files.pythonhosted.org/packages/d8/62/d490198d05d2d86672dc269f52579cad7261ced64c2df213d5c16e0aecb1/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d", size = 2108428 },
-    { url = "https://files.pythonhosted.org/packages/9a/ec/4cd215534fd10b8549015f12ea650a1a973da20ce46430b68fc3185573e8/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6", size = 2069854 },
-    { url = "https://files.pythonhosted.org/packages/1a/1a/abbd63d47e1d9b0d632fee6bb15785d0889c8a6e0a6c3b5a8e28ac1ec5d2/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca", size = 2237859 },
-    { url = "https://files.pythonhosted.org/packages/80/1c/fa883643429908b1c90598fd2642af8839efd1d835b65af1f75fba4d94fe/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039", size = 2239059 },
-    { url = "https://files.pythonhosted.org/packages/d4/29/3cade8a924a61f60ccfa10842f75eb12787e1440e2b8660ceffeb26685e7/pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27", size = 2066661 },
+    { url = "https://files.pythonhosted.org/packages/53/ea/bbe9095cdd771987d13c82d104a9c8559ae9aec1e29f139e286fd2e9256e/pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d", size = 2028677, upload-time = "2025-04-23T18:32:27.227Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1d/4ac5ed228078737d457a609013e8f7edc64adc37b91d619ea965758369e5/pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954", size = 1864735, upload-time = "2025-04-23T18:32:29.019Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9a/2e70d6388d7cda488ae38f57bc2f7b03ee442fbcf0d75d848304ac7e405b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb", size = 1898467, upload-time = "2025-04-23T18:32:31.119Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/2e/1568934feb43370c1ffb78a77f0baaa5a8b6897513e7a91051af707ffdc4/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7", size = 1983041, upload-time = "2025-04-23T18:32:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1a/1a1118f38ab64eac2f6269eb8c120ab915be30e387bb561e3af904b12499/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4", size = 2136503, upload-time = "2025-04-23T18:32:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/da/44754d1d7ae0f22d6d3ce6c6b1486fc07ac2c524ed8f6eca636e2e1ee49b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b", size = 2736079, upload-time = "2025-04-23T18:32:37.659Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/98/f43cd89172220ec5aa86654967b22d862146bc4d736b1350b4c41e7c9c03/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3", size = 2006508, upload-time = "2025-04-23T18:32:39.637Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cc/f77e8e242171d2158309f830f7d5d07e0531b756106f36bc18712dc439df/pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a", size = 2113693, upload-time = "2025-04-23T18:32:41.818Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7a/7be6a7bd43e0a47c147ba7fbf124fe8aaf1200bc587da925509641113b2d/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782", size = 2074224, upload-time = "2025-04-23T18:32:44.033Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/31cf8fadffbb03be1cb520850e00a8490c0927ec456e8293cafda0726184/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9", size = 2245403, upload-time = "2025-04-23T18:32:45.836Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8d/bbaf4c6721b668d44f01861f297eb01c9b35f612f6b8e14173cb204e6240/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e", size = 2242331, upload-time = "2025-04-23T18:32:47.618Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/93/3cc157026bca8f5006250e74515119fcaa6d6858aceee8f67ab6dc548c16/pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9", size = 1910571, upload-time = "2025-04-23T18:32:49.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/90/7edc3b2a0d9f0dda8806c04e511a67b0b7a41d2187e2003673a996fb4310/pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3", size = 1956504, upload-time = "2025-04-23T18:32:51.287Z" },
+    { url = "https://files.pythonhosted.org/packages/08/98/dbf3fdfabaf81cda5622154fda78ea9965ac467e3239078e0dcd6df159e7/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101", size = 2024034, upload-time = "2025-04-23T18:33:32.843Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/99/7810aa9256e7f2ccd492590f86b79d370df1e9292f1f80b000b6a75bd2fb/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64", size = 1858578, upload-time = "2025-04-23T18:33:34.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/60/bc06fa9027c7006cc6dd21e48dbf39076dc39d9abbaf718a1604973a9670/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d", size = 1892858, upload-time = "2025-04-23T18:33:36.933Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/40/9d03997d9518816c68b4dfccb88969756b9146031b61cd37f781c74c9b6a/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535", size = 2068498, upload-time = "2025-04-23T18:33:38.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/62/d490198d05d2d86672dc269f52579cad7261ced64c2df213d5c16e0aecb1/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d", size = 2108428, upload-time = "2025-04-23T18:33:41.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ec/4cd215534fd10b8549015f12ea650a1a973da20ce46430b68fc3185573e8/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6", size = 2069854, upload-time = "2025-04-23T18:33:43.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1a/abbd63d47e1d9b0d632fee6bb15785d0889c8a6e0a6c3b5a8e28ac1ec5d2/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca", size = 2237859, upload-time = "2025-04-23T18:33:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1c/fa883643429908b1c90598fd2642af8839efd1d835b65af1f75fba4d94fe/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039", size = 2239059, upload-time = "2025-04-23T18:33:47.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/3cade8a924a61f60ccfa10842f75eb12787e1440e2b8660ceffeb26685e7/pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27", size = 2066661, upload-time = "2025-04-23T18:33:49.995Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -526,9 +526,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750 },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -540,9 +540,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328 }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424 },
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]
@@ -552,9 +552,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -564,44 +564,44 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-immutable" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/51/3c746a5a0925dce853f19a19705753d188ff3abe055ce9655dce1762dd92/python_debouncer-0.1.5.tar.gz", hash = "sha256:ad4bc0229334f12cf0268a55c76ea98cb89a28f933c12fb556f92623e0c72b04", size = 7429 }
+sdist = { url = "https://files.pythonhosted.org/packages/98/51/3c746a5a0925dce853f19a19705753d188ff3abe055ce9655dce1762dd92/python_debouncer-0.1.5.tar.gz", hash = "sha256:ad4bc0229334f12cf0268a55c76ea98cb89a28f933c12fb556f92623e0c72b04", size = 7429, upload-time = "2024-07-19T15:35:27.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/06/6044f6ccc2b07755e8d3da794c79ac90daeaab1008470cc2484050c0366d/python_debouncer-0.1.5-py3-none-any.whl", hash = "sha256:d92bef943f169f93b5be79bc5c71e315f155ec7090e95c02a14c420ebdd4765d", size = 8204 },
+    { url = "https://files.pythonhosted.org/packages/79/06/6044f6ccc2b07755e8d3da794c79ac90daeaab1008470cc2484050c0366d/python_debouncer-0.1.5-py3-none-any.whl", hash = "sha256:d92bef943f169f93b5be79bc5c71e315f155ec7090e95c02a14c420ebdd4765d", size = 8204, upload-time = "2024-07-19T15:35:26.044Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256 },
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
 ]
 
 [[package]]
 name = "python-immutable"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/bc/2964193443e82cf0579ecf50e5dcc014d777b60347ffafebc1f958d834a1/python_immutable-1.2.2.tar.gz", hash = "sha256:52e701a4c2feb3b9013bcb412a731236fd6e402279de01b4df43ec6cba01815a", size = 7654 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/bc/2964193443e82cf0579ecf50e5dcc014d777b60347ffafebc1f958d834a1/python_immutable-1.2.2.tar.gz", hash = "sha256:52e701a4c2feb3b9013bcb412a731236fd6e402279de01b4df43ec6cba01815a", size = 7654, upload-time = "2025-06-06T16:02:24.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/c9/1aaa7d9d8fc4b5a62648b756c3356ff86690e02ee1c20939a9f592e498f5/python_immutable-1.2.2-py3-none-any.whl", hash = "sha256:33236c8082ee103f43ac3a95842742ae406c5faf3cb0c29ed98b2f34d922318c", size = 7773 },
+    { url = "https://files.pythonhosted.org/packages/e8/c9/1aaa7d9d8fc4b5a62648b756c3356ff86690e02ee1c20939a9f592e498f5/python_immutable-1.2.2-py3-none-any.whl", hash = "sha256:33236c8082ee103f43ac3a95842742ae406c5faf3cb0c29ed98b2f34d922318c", size = 7773, upload-time = "2025-06-06T16:02:22.382Z" },
 ]
 
 [[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777 },
-    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318 },
-    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891 },
-    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614 },
-    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360 },
-    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006 },
-    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577 },
-    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593 },
-    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312 },
+    { url = "https://files.pythonhosted.org/packages/65/d8/b7a1db13636d7fb7d4ff431593c510c8b8fca920ade06ca8ef20015493c5/PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d", size = 184777, upload-time = "2024-08-06T20:33:25.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/02/6ec546cd45143fdf9840b2c6be8d875116a64076218b61d68e12548e5839/PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f", size = 172318, upload-time = "2024-08-06T20:33:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/8cc68be846c972bda34f6c2a93abb644fb2476f4dcc924d52175786932c9/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290", size = 720891, upload-time = "2024-08-06T20:33:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6c/6e1b7f40181bc4805e2e07f4abc10a88ce4648e7e95ff1abe4ae4014a9b2/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12", size = 722614, upload-time = "2024-08-06T20:33:34.157Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/32/e7bd8535d22ea2874cef6a81021ba019474ace0d13a4819c2a4bce79bd6a/PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19", size = 737360, upload-time = "2024-08-06T20:33:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/12/7322c1e30b9be969670b672573d45479edef72c9a0deac3bb2868f5d7469/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e", size = 699006, upload-time = "2024-08-06T20:33:37.501Z" },
+    { url = "https://files.pythonhosted.org/packages/82/72/04fcad41ca56491995076630c3ec1e834be241664c0c09a64c9a2589b507/PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725", size = 723577, upload-time = "2024-08-06T20:33:39.389Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/5e/46168b1f2757f1fcd442bc3029cd8767d88a98c9c05770d8b420948743bb/PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631", size = 144593, upload-time = "2024-08-06T20:33:46.63Z" },
+    { url = "https://files.pythonhosted.org/packages/19/87/5124b1c1f2412bb95c59ec481eaf936cd32f0fe2a7b16b97b81c4c017a6a/PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8", size = 162312, upload-time = "2024-08-06T20:33:49.073Z" },
 ]
 
 [[package]]
@@ -614,9 +614,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -627,9 +627,9 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -639,45 +639,45 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036 }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248 },
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
 ]
 
 [[package]]
 name = "tomli"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -687,34 +687,34 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
 
 [[package]]
 name = "websocket-client"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576 }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616 },
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]
 name = "zipp"
 version = "3.23.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
*Note:  PR description was written by @aaco-accenture. I am opening this PR to add the uv sync updates and version bump needed to coordinate the build process.*

**Related PR**
- **Reference Merged PR:** #98 

**Problems**
- Warnings emitted by third-party libraries (e.g., the `google-auth` `FutureWarning` on Python 3.9) are written to stderr at import time and end up mixed into the response passed to HostFactory, which expects clean JSON on stdout. This causes JSON parse failures and breaks the provider.
- Complements #92 , which redirects the wrapper scripts' stderr into the provider log.  #92  covers output Python cannot intercept (native/C-level stderr from grpc, anything emitted before the interpreter reaches the entry module), while this PR captures Python-level warnings at the source and guarantees the providers' own logging can never target stderr. 
-  The hf-provider README install and test steps run against different versions than the build step #95 


**Fix**

- Add `common/log_bootstrap.py`. It attaches a single rotating file handler to the root logger and enables `logging.captureWarnings` so `warnings.warn` output is logged instead of written to stderr. The log path resolves from the same HostFactory variables the wrapper scripts use (`HF_PROVIDER_LOGDIR`, `HF_PROVIDER_NAME`, `EGOSC_INSTANCE_HOST`, with hostname as a fallback), and falls back to the system temp dir mirroring #92 so both the wrapper layer and the Python layer write to the same file. If no location is writable, it degrades to a `NullHandler` rather than ever attaching a stream handler.
- Call `bootstrap_logging()` first in all three entry points (`hf-gce`, `hf-gke`, `hf-monitor`), before any third-party import, so import-time warnings are captured.
- `Config` in both providers now delegates to `log_bootstrap.configure_logging(...)`, which re-applies the log file, level, and rotation limits from the provider JSON. This removes the previous duplicated `basicConfig` + `addHandler` setup, which had three problems: every record was written twice, the same file was rotated by two handlers at once, and when `HF_PROVIDER_LOGDIR` was unset it attached a stderr stream handler and created a file literally named `None`.
- Failure-path contract: commands that fail now log the full traceback to the provider log and exit 1 with the error message on stdout, per the HF script contract documented in the wrapper-script headers. `hf-gke` previously printed `ERROR: Command returned empty result` to stdout with exit 0, which HostFactory would try to parse as a success response. It now exits 1.
- Use uv.lock for both source and RPM build pipelines


**Scope**
GCE and GKE providers, hf-monitor.



**Verified at three levels:**
Unit and contract tests (new):
- `tests/unit/common/test_log_bootstrap.py`: warnings are routed to the log and never to stdout/stderr; log path matches the wrapper scripts' fallback chain; bootstrap is idempotent, reinstalls after external handler removal, and degrades to a `NullHandler` when nothing is writable; provider JSON settings are re-applied.
- `tests/unit/{gce,gke}_provider/test_stdout_contract.py`: run the real CLIs in a subprocess with `PYTHONWARNINGS=always` and assert stdout parses as JSON with nothing else, stderr is empty, failures exit 1 with the error message on stdout, and the traceback lands in the provider log.


Script-level:
- Built the provider binaries from source against `google-auth==2.47.0` (matching `hf-gcpgce-provider-1.0.0-110.el10.x86_64`).
- Invoked the binaries directly and via the wrapper scripts: stdout contains only the JSON response; the `FutureWarning` appears in the provider log instead of stderr.


End-to-end with the Cluster Management Console:
- Restarted HostFactory: `egosh service stop HostFactory` / `egosh service start HostFactory`.
- Confirmed templates list correctly, scheduled a machine request, and returned the machines through the console.
- Confirmed warnings from these invocations are appended to the provider log and no longer reach stdout/stderr.


**Affected Files**
Source:
- hf-provider/src/common/log_bootstrap.py (new)
- hf-provider/src/gce_provider/\_\_main\_\_.py
- hf-provider/src/gce_provider/config.py
- hf-provider/src/gce_provider/pubsub.py
- hf-provider/src/gke_provider/\_\_main\_\_.py
- hf-provider/src/gke_provider/config.py

Tests (new):
- hf-provider/tests/unit/conftest.py
- hf-provider/tests/unit/common/test_log_bootstrap.py
- hf-provider/tests/unit/gce_provider/test_stdout_contract.py
- hf-provider/tests/unit/gke_provider/test_stdout_contract.py

Bump hf-provider from 0.3.6 to 0.3.7

**Checklist**
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

Fixes: #86, #95