### PR TITLE
fix(gce): fail fast when configured GCP_CREDENTIALS_FILE is invalid instead of falling back to ADC

### DIFF
--- a/hf-provider/src/gce_provider/utils/client_factory.py
+++ b/hf-provider/src/gce_provider/utils/client_factory.py
@@ -1,6 +1,4 @@
-import logging
 from functools import lru_cache
-from pathlib import Path
 from typing import Optional
 
 import google.cloud.compute_v1 as compute
@@ -19,26 +17,27 @@ def get_credentials(
     if config is None:
         config = get_config()
 
-    if config.gcp_credentials_file:
-        credentials_file_path = normalize_path(
-            config.hf_provider_conf_dir, config.gcp_credentials_file
+    if not config.gcp_credentials_file:
+        config.logger.warning(
+            "No credentials file defined. Will rely on application default credentials."
         )
+        return None
 
-        if Path(credentials_file_path).exists():
-            try:
-                credentials_json = load_json_file(credentials_file_path)
-                return service_account.Credentials.from_service_account_info(
-                    credentials_json
-                )
-            except Exception as e:
-                config.logger.exception(
-                    f"Unable to create service account credentials from file {credentials_file_path}: {e}"
-                )
-
-    logging.warning(
-        "No credentials file defined, or file does not exist. Will rely on application default credentials."
+    credentials_file_path = normalize_path(
+        config.hf_provider_conf_dir, config.gcp_credentials_file
     )
-    return None
+
+    try:
+        credentials_json = load_json_file(credentials_file_path)
+        return service_account.Credentials.from_service_account_info(credentials_json)
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            f"GCP_CREDENTIALS_FILE is set but the file does not exist: {credentials_file_path}"
+        ) from e
+    except Exception as e:
+        raise RuntimeError(
+            f"GCP_CREDENTIALS_FILE is set but could not be loaded as service account credentials: {credentials_file_path}"
+        ) from e
 
 
 @lru_cache(maxsize=1)

--- a/hf-provider/tests/unit/gce_provider/test_client_factory.py
+++ b/hf-provider/tests/unit/gce_provider/test_client_factory.py
@@ -39,10 +39,12 @@ def test_uses_global_config_when_none_passed():
     mock_get_config.assert_called_once()
 
 
-def test_returns_none_when_file_missing(tmp_path):
-    """Configured-but-missing credentials file falls back to ADC (returns None)."""
+def test_raises_when_file_missing(tmp_path):
+    """Configured but missing credentials file fails fast instead of falling back to ADC."""
     config = make_config(credentials_file="missing_gcp_credentials_file.json", conf_dir=str(tmp_path))
-    assert client_factory.get_credentials(config) is None
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        client_factory.get_credentials(config)
 
 
 def test_resolves_relative_path_against_confdir(tmp_path):
@@ -64,18 +66,16 @@ def test_resolves_relative_path_against_confdir(tmp_path):
     mock_from_info.assert_called_once_with(sa_info)
 
 
-def test_falls_back_to_none_when_credential_load_fails(tmp_path):
-    """When GCP rejects the key file, swallow, log, and fall back to ADC (returns None)."""
+def test_raises_when_credential_load_fails(tmp_path):
+    """When GCP rejects the key file, fail fast instead of falling back to ADC"""
     creds = tmp_path / "test_gcp_credentials_file.json"
     creds.write_text("{}")
     config = make_config(credentials_file="test_gcp_credentials_file.json", conf_dir=str(tmp_path))
 
-    with patch.object(
-        service_account.Credentials,
-        "from_service_account_info",
-        side_effect=ValueError("bad key"),
-    ):
-        result = client_factory.get_credentials(config)
-
-    assert result is None
-    config.logger.exception.assert_called_once()
+    with pytest.raises(RuntimeError, match="could not be loaded"):
+        with patch.object(
+            service_account.Credentials,
+            "from_service_account_info",
+            side_effect=ValueError("bad key"),
+        ):
+            client_factory.get_credentials(config)


### PR DESCRIPTION
**Problem**
When `GCP_CREDENTIALS_FILE` is set but the file is missing or cannot be loaded as service account credentials, `get_credentials()` logs a warning and silently falls back ADC. This hides operator misconfiguration and can make the provider authenticate as an unintended identity. The fallback was kept in #97  to preserve existing behavior; #102  agreed to remove it.

**Change**
If `GCP_CREDENTIALS_FILE` is set, the file must exist and load as valid service account credentials, otherwise the provider raises an error. If `GCP_CREDENTIALS_FILE` is unset, the ADC path is unchanged.

**Scope**
GCE provider (`hf-gce`) only. The GKE provider (`hf-gke`) authenticates through a kubeconfig and is unaffected.

**Affected files**
- hf-provider/src/gce_provider/utils/client_factory.py
- hf-provider/tests/unit/gce_provider/test_client_factory.py


**Checklist**
- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR

Fixes: #102