### PR TITLE
docs: update image paths for GKE and GCE class diagrams

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,7 +17,7 @@ This document is a design proposal for implementing a **HostFactory provider plu
 
 ### Class Diagram
 
-![image-20250904104210953](/Users/cory.y.kim/code/google/google-symphony-hf/docs/architecture/assets/gke-components.png)
+![image-20250904104210953](assets/gke-components.png)
 
 ### Shell Scripts
 
@@ -144,7 +144,7 @@ The Symphony GKE blueprint and associated Terraform modules will be included in 
 
 ### Class Diagram
 
-![image-20250904104210953](/Users/cory.y.kim/code/google/google-symphony-hf/docs/architecture/assets/gce-components.png)
+![image-20250904104210953](assets/gce-components.png)
 
 ### Shell Scripts
 


### PR DESCRIPTION
Fix images that uses absolute paths on [architecture#gke-connector](https://github.com/google/symphony-gcp/tree/main/docs/architecture#gke-connector) and [architecture#gce-connector ](https://github.com/google/symphony-gcp/tree/main/docs/architecture#gce-connector).

**Before:**
<img width="1920" height="996" alt="Screenshot 2026-08-06 224737" src="https://github.com/user-attachments/assets/ddab61d5-41c2-48b8-a976-6726f90cdac5" />
<img width="1920" height="996" alt="Screenshot 2026-08-06 224706" src="https://github.com/user-attachments/assets/2a530218-afa9-4df9-ae7f-40cfb30640d4" />


**After:**
<img width="1920" height="1000" alt="Screenshot 2026-08-06 224821" src="https://github.com/user-attachments/assets/5897191f-f93e-45b8-b242-93827dcd9978" />
<img width="1920" height="1000" alt="Screenshot 2026-08-06 224829" src="https://github.com/user-attachments/assets/5f4b9a25-41f6-4254-88f0-73cba3e30bf1" />

- [x] Tests pass (docs only)
- [x] Appropriate changes to documentation are included in the PR
